### PR TITLE
Add GitHub Actions CI, fix code quality and lint issues

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,7 +26,7 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Run lint
-        run: ./gradlew lintDebug
+        run: ./gradlew lintDebug -Dlint.baselines.continue=true
 
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest
@@ -44,3 +44,32 @@ jobs:
         with:
           name: test-report
           path: app/build/reports/tests/testDebugUnitTest/
+
+  build-whitebikes:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build WhiteBikes APK
+        run: >
+          ./gradlew assembleDebug
+          -PAPP_NAME="WhiteBikes"
+          -PAPI_BASE_URL="https://whitebikes.info/api/v1/"
+          -PLOGO_URL="https://whitebikes.info/images/logo_small.svg"
+
+      - name: Upload WhiteBikes APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: whitebikes-apk
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,12 @@ android {
         compose = true
         buildConfig = true
     }
+
+    lint {
+        abortOnError = true
+        warningsAsErrors = false
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/bikeshare/app/notification/FreeTimeNotificationWorker.kt
+++ b/app/src/main/java/com/bikeshare/app/notification/FreeTimeNotificationWorker.kt
@@ -1,11 +1,14 @@
 package com.bikeshare.app.notification
 
+import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.bikeshare.app.R
@@ -31,6 +34,11 @@ class FreeTimeNotificationWorker(
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             .build()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_BASE + bikeNumber, notification)
     }
 

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -140,11 +140,10 @@ fun AppNavGraph(
                 )
             }
 
-            composable(Screen.Map.route) {
-                val mapBackStackEntry = remember { navController.getBackStackEntry(Screen.Map.route) }
+            composable(Screen.Map.route) { backStackEntry ->
                 MapScreen(
                     onScanQr = { navController.navigate(Screen.QrScanner.route) },
-                    qrSavedStateHandle = mapBackStackEntry.savedStateHandle,
+                    qrSavedStateHandle = backStackEntry.savedStateHandle,
                 )
             }
 

--- a/app/src/main/java/com/bikeshare/app/ui/scanner/QrScannerScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/scanner/QrScannerScreen.kt
@@ -38,7 +38,7 @@ import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.common.InputImage
 import java.util.concurrent.Executors
 
-@OptIn(ExperimentalMaterial3Api::class, androidx.camera.core.ExperimentalGetImage::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QrScannerScreen(
     onBack: () -> Unit,
@@ -189,7 +189,7 @@ private fun ScanOverlay() {
     }
 }
 
-@androidx.camera.core.ExperimentalGetImage
+@androidx.annotation.OptIn(androidx.camera.core.ExperimentalGetImage::class)
 private fun processImage(
     imageProxy: ImageProxy,
     scanner: com.google.mlkit.vision.barcode.BarcodeScanner,


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow (build, lint, unit tests) on push/PR to master
- Disable cleartext traffic in AndroidManifest (HTTPS only)
- Remove `runBlocking` from auth interceptors — prevent potential ANR
- Make `TokenStorage` methods synchronous (SharedPreferences is already sync)
- Reuse `OkHttpClient` in `TokenRefreshAuthenticator` via lazy init
- Replace unsafe `!!` operators with smart casts
- Add Timber logging for silent error handlers in `MapViewModel`
- Fix lint error: check `POST_NOTIFICATIONS` permission before showing notification
- Add lint baseline config to track new errors without blocking on existing warnings

## Test plan

- [ ] Verify GitHub Actions CI passes (build + lint + tests)
- [ ] Test notification permission flow on Android 13+
- [ ] Verify auth token refresh still works correctly