### PR TITLE
Configure WhiteBikes build with GitHub variables and secrets

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -64,9 +64,10 @@ jobs:
       - name: Build WhiteBikes APK
         run: >
           ./gradlew assembleDebug
-          -PAPP_NAME="WhiteBikes"
-          -PAPI_BASE_URL="https://whitebikes.info/api/v1/"
-          -PLOGO_URL="https://whitebikes.info/images/logo_small.svg"
+          -PAPP_NAME="${{ vars.APP_NAME }}"
+          -PAPI_BASE_URL="${{ vars.API_BASE_URL }}"
+          -PLOGO_URL="${{ vars.LOGO_URL }}"
+          -PSENTRY_DSN="${{ secrets.SENTRY_DSN }}"
 
       - name: Upload WhiteBikes APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Use repository **variables** (`vars.APP_NAME`, `vars.API_BASE_URL`, `vars.LOGO_URL`) for non-sensitive build config — visible in logs for easier debugging
- Use repository **secret** (`secrets.SENTRY_DSN`) for Sentry DSN — masked in logs

## Prerequisites

The following have been configured in repository settings:

**Variables:**
- `APP_NAME` = WhiteBikes
- `API_BASE_URL` = https://whitebikes.info/api/v1/
- `LOGO_URL` = https://whitebikes.info/images/logo_small.svg

**Secrets:**
- `SENTRY_DSN` = (configured)

## Test plan

- [ ] Merge and verify `build-whitebikes` job runs on master push
- [ ] Check APK artifact is uploaded with correct branding