### PR TITLE
Add release pipeline with signed APK

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,6 +3,7 @@ name: Android CI
 on:
   push:
     branches: [ master ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ master ]
 
@@ -74,3 +75,77 @@ jobs:
         with:
           name: whitebikes-apk
           path: app/build/outputs/apk/debug/app-debug.apk
+
+  release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          VERSION_CODE=$(git rev-list --count HEAD)
+          echo "version_name=$TAG" >> $GITHUB_OUTPUT
+          echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
+
+      - name: Decode keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ${{ runner.temp }}/release.keystore
+
+      - name: Build signed release APK
+        env:
+          KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: >
+          ./gradlew assembleRelease
+          -PVERSION_NAME="${{ steps.version.outputs.version_name }}"
+          -PVERSION_CODE="${{ steps.version.outputs.version_code }}"
+          -PAPP_NAME="${{ vars.APP_NAME }}"
+          -PAPI_BASE_URL="${{ vars.API_BASE_URL }}"
+          -PLOGO_URL="${{ vars.LOGO_URL }}"
+          -PSENTRY_DSN="${{ secrets.SENTRY_DSN }}"
+
+      - name: Rename APK
+        run: |
+          mv app/build/outputs/apk/release/app-release.apk \
+             app/build/outputs/apk/release/WhiteBikes-${{ steps.version.outputs.version_name }}.apk
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            LOG=$(git log --pretty=format:"- %s" "$PREV_TAG"..HEAD)
+          else
+            LOG=$(git log --pretty=format:"- %s" -20)
+          fi
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$LOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: WhiteBikes v${{ steps.version.outputs.version_name }}
+          body: |
+            ## Changes
+            ${{ steps.changelog.outputs.changelog }}
+          files: app/build/outputs/apk/release/WhiteBikes-${{ steps.version.outputs.version_name }}.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,12 +10,15 @@ android {
     namespace = "com.bikeshare.app"
     compileSdk = 35
 
+    val tagVersion = (project.findProperty("VERSION_NAME") as? String)?.takeIf { it.isNotBlank() } ?: "1.0.0"
+    val commitCount = (project.findProperty("VERSION_CODE") as? String)?.toIntOrNull() ?: 1
+
     defaultConfig {
         applicationId = "com.bikeshare.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0.0"
+        versionCode = commitCount
+        versionName = tagVersion
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -34,6 +37,18 @@ android {
         resValue("string", "app_name", appName)
     }
 
+    signingConfigs {
+        create("release") {
+            val ksFile = file(System.getenv("KEYSTORE_FILE") ?: "release.keystore")
+            if (ksFile.exists()) {
+                storeFile = ksFile
+                storePassword = System.getenv("KEYSTORE_PASSWORD") ?: ""
+                keyAlias = System.getenv("KEY_ALIAS") ?: ""
+                keyPassword = System.getenv("KEY_PASSWORD") ?: ""
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
@@ -42,6 +57,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.findByName("release")
         }
         debug {
             isMinifyEnabled = false

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -21,3 +21,9 @@
 
 # osmdroid
 -dontwarn org.osmdroid.**
+
+# EncryptedSharedPreferences / Security Crypto
+-keep class androidx.security.crypto.** { *; }
+
+# Sentry
+-dontwarn io.sentry.**


### PR DESCRIPTION
## Summary
- Add release signing config in `build.gradle.kts` (keystore via env variables)
- Add dynamic versioning from git tags (`v1.2.3` → versionName `1.2.3`, versionCode from commit count)
- Add `release` job in CI: triggered on `v*` tags, builds signed APK, creates GitHub Release
- Update ProGuard rules for `security-crypto` and Sentry

## How to release
1. Merge this PR
2. Create and push a tag: `git tag v0.1.0 && git push origin v0.1.0`
3. CI builds signed release APK → GitHub Release created automatically with `WhiteBikes-0.1.0.apk`

## Secrets required
- `KEYSTORE_BASE64` ✅
- `KEYSTORE_PASSWORD` ✅
- `KEY_ALIAS` ✅
- `KEY_PASSWORD` ✅

## Test plan
- [ ] CI build passes
- [ ] Push test tag → GitHub Release created with signed APK
- [ ] APK installs and runs on device