### PR TITLE
Fix release build lint baseline error

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -116,6 +116,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: >
           ./gradlew assembleRelease
+          -Dlint.baselines.continue=true
           -PVERSION_NAME="${{ steps.version.outputs.version_name }}"
           -PVERSION_CODE="${{ steps.version.outputs.version_code }}"
           -PAPP_NAME="${{ vars.APP_NAME }}"


### PR DESCRIPTION
## Summary
- Add `-Dlint.baselines.continue=true` to release build step to prevent failure when lint baseline doesn't exist yet

## Test plan
- [ ] Release workflow completes successfully