### PR TITLE
build: upgrade to AGP 9.1.1, Kotlin 2.2.10, compileSdk 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.bikeshare.app"
-    compileSdk = 35
+    compileSdk = 36
 
     val tagVersion = (project.findProperty("VERSION_NAME") as? String)?.takeIf { it.isNotBlank() } ?: "1.0.0"
     val commitCount = (project.findProperty("VERSION_CODE") as? String)?.toIntOrNull() ?: 1
@@ -70,8 +70,8 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 
     buildFeatures {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,10 +69,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-
     buildFeatures {
         compose = true
         buildConfig = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,7 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
+        resValues = true
     }
 
     lint {

--- a/app/src/main/java/com/bikeshare/app/data/local/TokenStorage.kt
+++ b/app/src/main/java/com/bikeshare/app/data/local/TokenStorage.kt
@@ -3,7 +3,7 @@ package com.bikeshare.app.data.local
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
+import androidx.security.crypto.MasterKey
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -13,10 +13,13 @@ class TokenStorage @Inject constructor(
     @ApplicationContext context: Context,
 ) {
     private val prefs: SharedPreferences = try {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
         EncryptedSharedPreferences.create(
-            "bikeshare_secure_prefs",
-            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
             context,
+            "bikeshare_secure_prefs",
+            masterKey,
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
         )

--- a/app/src/main/java/com/bikeshare/app/ui/admin/AdminDashboardScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/AdminDashboardScreen.kt
@@ -2,6 +2,7 @@ package com.bikeshare.app.ui.admin
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.DirectionsBike
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -38,7 +39,7 @@ fun AdminDashboardScreen(
                 onClick = onNavigateToStands,
             )
             AdminMenuItem(
-                icon = Icons.Default.DirectionsBike,
+                icon = Icons.AutoMirrored.Filled.DirectionsBike,
                 title = stringResource(R.string.admin_bikes),
                 onClick = onNavigateToBikes,
             )

--- a/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikeDetailScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikeDetailScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -219,7 +220,7 @@ fun AdminBikeDetailScreen(
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
                 ) {
-                    Icon(Icons.Default.Undo, contentDescription = null)
+                    Icon(Icons.AutoMirrored.Filled.Undo, contentDescription = null)
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(stringResource(R.string.admin_revert_bike_state))
                 }

--- a/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.DirectionsBike
+import androidx.compose.material.icons.automirrored.filled.DirectionsBike
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.*
@@ -86,7 +86,7 @@ fun AdminBikesScreen(
                                     modifier = Modifier.padding(16.dp),
                                     verticalAlignment = Alignment.CenterVertically,
                                 ) {
-                                    Icon(Icons.Default.DirectionsBike, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                                    Icon(Icons.AutoMirrored.Filled.DirectionsBike, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
                                     Spacer(modifier = Modifier.width(12.dp))
                                     Column {
                                         Text("#${bike.bikeNum}", style = MaterialTheme.typography.titleMedium)

--- a/app/src/main/java/com/bikeshare/app/ui/auth/RegisterScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/auth/RegisterScreen.kt
@@ -122,7 +122,7 @@ fun RegisterScreen(
                         label = { Text(stringResource(R.string.register_city)) },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                         modifier = Modifier
-                            .menuAnchor()
+                            .menuAnchor(MenuAnchorType.PrimaryNotEditable)
                             .fillMaxWidth(),
                     )
                     ExposedDropdownMenu(

--- a/app/src/main/java/com/bikeshare/app/ui/map/StandBottomSheet.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/StandBottomSheet.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DirectionsBike
-import androidx.compose.material.icons.filled.KeyboardReturn
+import androidx.compose.material.icons.automirrored.filled.DirectionsBike
+import androidx.compose.material.icons.automirrored.filled.KeyboardReturn
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -57,7 +57,7 @@ fun StandBottomSheet(
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary),
                 ) {
-                    Icon(Icons.Default.KeyboardReturn, contentDescription = null)
+                    Icon(Icons.AutoMirrored.Filled.KeyboardReturn, contentDescription = null)
                     Spacer(modifier = Modifier.width(8.dp))
                     Text("${stringResource(R.string.return_button)} #${bike.bikeNum}")
                 }
@@ -118,7 +118,7 @@ private fun BikeItem(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
-                    imageVector = Icons.Default.DirectionsBike,
+                    imageVector = Icons.AutoMirrored.Filled.DirectionsBike,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(28.dp),

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -2,7 +2,7 @@ package com.bikeshare.app.ui.navigation
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DirectionsBike
+import androidx.compose.material.icons.automirrored.filled.DirectionsBike
 import androidx.compose.material.icons.filled.Map
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
@@ -63,7 +63,7 @@ fun AppNavGraph(
 
     val baseNavItems = listOf(
         BottomNavItem(Screen.Map.route, { Icon(Icons.Default.Map, contentDescription = null) }, R.string.nav_map),
-        BottomNavItem(Screen.Rentals.route, { Icon(Icons.Default.DirectionsBike, contentDescription = null) }, R.string.nav_rentals),
+        BottomNavItem(Screen.Rentals.route, { Icon(Icons.AutoMirrored.Filled.DirectionsBike, contentDescription = null) }, R.string.nav_rentals),
         BottomNavItem(Screen.Profile.route, { Icon(Icons.Default.Person, contentDescription = null) }, R.string.nav_profile),
     )
     val bottomNavItems = if (isAdmin) {

--- a/app/src/main/java/com/bikeshare/app/ui/rental/RentalScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/rental/RentalScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DirectionsBike
+import androidx.compose.material.icons.automirrored.filled.DirectionsBike
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -58,7 +58,7 @@ fun RentalScreen(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Icon(
-                        Icons.Default.DirectionsBike,
+                        Icons.AutoMirrored.Filled.DirectionsBike,
                         contentDescription = null,
                         modifier = Modifier.size(64.dp),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -114,7 +114,7 @@ private fun RentedBikeCard(
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
-                        Icons.Default.DirectionsBike,
+                        Icons.AutoMirrored.Filled.DirectionsBike,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
                     )
@@ -188,7 +188,7 @@ private fun ReturnBikeDialog(
                         readOnly = true,
                         label = { Text(stringResource(R.string.select_stand)) },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
-                        modifier = Modifier.menuAnchor().fillMaxWidth(),
+                        modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
                     )
                     ExposedDropdownMenu(
                         expanded = expanded,

--- a/app/src/main/java/com/bikeshare/app/ui/scanner/QrScannerScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/scanner/QrScannerScreen.kt
@@ -2,7 +2,6 @@ package com.bikeshare.app.ui.scanner
 
 import android.Manifest
 import android.content.pm.PackageManager
-import android.util.Size
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.CameraSelector
@@ -102,7 +101,13 @@ fun QrScannerScreen(
                             val barcodeScanner = BarcodeScanning.getClient()
 
                             val imageAnalysis = ImageAnalysis.Builder()
-                                .setTargetResolution(Size(1280, 720))
+                                .setResolutionSelector(
+                                    androidx.camera.core.resolutionselector.ResolutionSelector.Builder()
+                                        .setAspectRatioStrategy(
+                                            androidx.camera.core.resolutionselector.AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY
+                                        )
+                                        .build()
+                                )
                                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                                 .build()
                                 .also { analysis ->

--- a/app/src/main/java/com/bikeshare/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/theme/Theme.kt
@@ -53,6 +53,7 @@ fun BikeShareTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
+            @Suppress("DEPRECATION")
             window.statusBarColor = colorScheme.primary.toArgb()
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+android.disallowKotlinSourceSets=false
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 
 # Optional build-time config (defaults used if unset):

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-agp = "8.7.3"
-kotlin = "2.1.0"
-coreKtx = "1.15.0"
+agp = "9.1.1"
+kotlin = "2.2.10"
+coreKtx = "1.17.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
-composeBom = "2024.12.01"
-navigationCompose = "2.8.5"
-hilt = "2.53.1"
+composeBom = "2026.03.01"
+navigationCompose = "2.9.7"
+hilt = "2.59.2"
 hiltNavigationCompose = "1.3.0"
 retrofit = "3.0.0"
 okhttp = "4.12.0"
@@ -25,7 +25,7 @@ sentry = "8.34.1"
 junit = "4.13.2"
 junitExt = "1.3.0"
 espresso = "3.6.1"
-ksp = "2.1.0-1.0.29"
+ksp = "2.2.10-2.0.2"
 
 [libraries]
 # AndroidX Core


### PR DESCRIPTION
## Summary
Major toolchain and dependency upgrade that unblocks all remaining Dependabot PRs.

### Toolchain
- AGP 8.7.3 → **9.1.1**
- Kotlin 2.1.0 → **2.2.10**
- KSP 2.1.0-1.0.29 → **2.2.10-2.0.2**
- compileSdk 35 → **36**

### Dependencies
- Compose BOM 2024.12.01 → **2026.03.01**
- navigation-compose 2.8.5 → **2.9.7** (closes #14)
- core-ktx 1.15.0 → **1.17.0** (closes #24)
- hilt 2.53.1 → **2.59.2** (closes #18)

### Deprecation fixes
- `Icons.Default.DirectionsBike/Undo/KeyboardReturn` → `Icons.AutoMirrored.Filled.*`
- `Modifier.menuAnchor()` → `menuAnchor(MenuAnchorType.PrimaryNotEditable)`
- `kotlinOptions` → `compilerOptions` in build.gradle.kts
- `MasterKeys` → `MasterKey.Builder` in TokenStorage
- `setTargetResolution` → `setResolutionSelector` in QrScanner

Supersedes #30.

## Test plan
- [ ] CI build passes
- [ ] App starts and navigates correctly
- [ ] QR scanner works
- [ ] Encrypted token storage works
- [ ] Dropdown menus work (Register, Return bike)
- [ ] Admin screens load correctly