### PR TITLE
build: add Sentry Gradle plugin for mapping file upload

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -114,6 +114,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: >
           ./gradlew assembleRelease
           -Dlint.baselines.continue=true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.sentry.android)
 }
 
 android {
@@ -154,4 +155,25 @@ dependencies {
     androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test.junit4)
     debugImplementation(libs.compose.ui.test.manifest)
+}
+
+sentry {
+    org.set("whitebikes")
+    projectName.set("android")
+    authToken.set(System.getenv("SENTRY_AUTH_TOKEN") ?: "")
+
+    // Upload ProGuard/R8 mapping files for release builds so obfuscated stack
+    // traces become readable in Sentry.
+    includeProguardMapping.set(true)
+    autoUploadProguardMapping.set(true)
+
+    // Upload source context so Sentry can show the actual lines of code
+    // where an exception was thrown.
+    includeSourceContext.set(true)
+    autoUploadSourceContext.set(true)
+
+    // Don't upload anything for debug builds.
+    ignoredBuildTypes.set(setOf("debug"))
+
+    telemetry.set(false)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ timber = "5.0.1"
 coroutines = "1.9.0"
 work = "2.11.1"
 sentry = "8.34.1"
+sentryGradle = "6.4.0"
 junit = "4.13.2"
 junitExt = "1.3.0"
 espresso = "3.6.1"
@@ -105,3 +106,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+sentry-android = { id = "io.sentry.android.gradle", version.ref = "sentryGradle" }


### PR DESCRIPTION
## Summary
Adds `io.sentry.android.gradle` plugin 6.4.0 to automatically upload R8 mapping files and source context to Sentry for release builds.

## Why
Current Sentry stack traces for release builds are obfuscated and unreadable:
\`\`\`
at cq0.run(r8-map-id-d07876298de2308a414678a824ef452f5a3a1d4ecac23393a94db4e7e302fa14:84)
\`\`\`

After this change, Sentry will deobfuscate stack traces using the uploaded mapping file and show actual source line context.

## Changes
- `libs.versions.toml`: `sentryGradle = "6.4.0"` + plugin alias
- `app/build.gradle.kts`: plugin applied + `sentry {}` configuration block
- `.github/workflows/android.yml`: `SENTRY_AUTH_TOKEN` env var added to release job
- Debug builds are skipped (`ignoredBuildTypes`)

## Prerequisites
Repo owner must add `SENTRY_AUTH_TOKEN` secret in GitHub repo settings:
1. Sentry → Settings → Auth Tokens → Create New Token
2. Scopes required: `project:releases`, `org:read`
3. GitHub repo → Settings → Secrets and variables → Actions → New repository secret
4. Name: \`SENTRY_AUTH_TOKEN\`, Value: \`sntrys_...\`

## Test plan
- [ ] CI passes on this PR (plugin doesn't break debug builds)
- [ ] After merge + new tag release, mapping file is uploaded to Sentry
- [ ] Next crash in Sentry shows deobfuscated stack trace