### PR TITLE
feat: check for app updates via GitHub Releases API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,11 +27,14 @@ android {
         val apiBaseUrl = (project.findProperty("API_BASE_URL") as? String)?.takeIf { it.isNotBlank() } ?: "https://whitebikes.info/api/v1/"
 
         val sentryDsn = (project.findProperty("SENTRY_DSN") as? String)?.takeIf { it.isNotBlank() } ?: ""
+        val updateCheckUrl = (project.findProperty("UPDATE_CHECK_URL") as? String)?.takeIf { it.isNotBlank() }
+            ?: "https://api.github.com/repos/cyklokoalicia/OpenSourceBikeShare-Android/releases/latest"
 
         buildConfigField("String", "API_BASE_URL", "\"$apiBaseUrl\"")
         buildConfigField("String", "APP_NAME", "\"$appName\"")
         buildConfigField("String", "LOGO_URL", "\"$logoUrl\"")
         buildConfigField("String", "SENTRY_DSN", "\"$sentryDsn\"")
+        buildConfigField("String", "UPDATE_CHECK_URL", "\"$updateCheckUrl\"")
 
         resValue("string", "app_name", appName)
     }

--- a/app/src/main/java/com/bikeshare/app/data/api/github/GitHubApiService.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/github/GitHubApiService.kt
@@ -1,0 +1,10 @@
+package com.bikeshare.app.data.api.github
+
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Url
+
+interface GitHubApiService {
+    @GET
+    suspend fun getLatestRelease(@Url url: String): Response<GitHubReleaseDto>
+}

--- a/app/src/main/java/com/bikeshare/app/data/api/github/GitHubReleaseDto.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/github/GitHubReleaseDto.kt
@@ -1,0 +1,13 @@
+package com.bikeshare.app.data.api.github
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class GitHubReleaseDto(
+    @Json(name = "tag_name") val tagName: String,
+    @Json(name = "html_url") val htmlUrl: String,
+    @Json(name = "name") val name: String? = null,
+    @Json(name = "prerelease") val prerelease: Boolean = false,
+    @Json(name = "draft") val draft: Boolean = false,
+)

--- a/app/src/main/java/com/bikeshare/app/di/GitHubModule.kt
+++ b/app/src/main/java/com/bikeshare/app/di/GitHubModule.kt
@@ -1,0 +1,34 @@
+package com.bikeshare.app.di
+
+import com.bikeshare.app.data.api.github.GitHubApiService
+import com.squareup.moshi.Moshi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object GitHubModule {
+
+    @Provides
+    @Singleton
+    fun provideGitHubApiService(moshi: Moshi): GitHubApiService {
+        val client = OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .build()
+
+        return Retrofit.Builder()
+            .baseUrl("https://api.github.com/")
+            .client(client)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+            .create(GitHubApiService::class.java)
+    }
+}

--- a/app/src/main/java/com/bikeshare/app/domain/update/UpdateChecker.kt
+++ b/app/src/main/java/com/bikeshare/app/domain/update/UpdateChecker.kt
@@ -1,0 +1,43 @@
+package com.bikeshare.app.domain.update
+
+import com.bikeshare.app.BuildConfig
+import com.bikeshare.app.data.api.github.GitHubApiService
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UpdateChecker @Inject constructor(
+    private val api: GitHubApiService,
+) {
+    suspend fun checkForUpdate(): UpdateInfo? {
+        if (BuildConfig.UPDATE_CHECK_URL.isBlank()) return null
+
+        val release = runCatching { api.getLatestRelease(BuildConfig.UPDATE_CHECK_URL) }
+            .getOrNull()?.takeIf { it.isSuccessful }?.body()
+            ?: return null
+
+        if (release.draft || release.prerelease) return null
+
+        val latest = release.tagName.removePrefix("v")
+        val current = BuildConfig.VERSION_NAME
+
+        return if (isNewer(latest, current)) {
+            Timber.i("Update available: $current → $latest")
+            UpdateInfo(latestVersion = latest, releaseUrl = release.htmlUrl)
+        } else {
+            null
+        }
+    }
+
+    private fun isNewer(latest: String, current: String): Boolean {
+        val l = latest.split('.').mapNotNull { it.toIntOrNull() }
+        val c = current.split('.').mapNotNull { it.toIntOrNull() }
+        for (i in 0 until maxOf(l.size, c.size)) {
+            val a = l.getOrElse(i) { 0 }
+            val b = c.getOrElse(i) { 0 }
+            if (a != b) return a > b
+        }
+        return false
+    }
+}

--- a/app/src/main/java/com/bikeshare/app/domain/update/UpdateInfo.kt
+++ b/app/src/main/java/com/bikeshare/app/domain/update/UpdateInfo.kt
@@ -1,0 +1,6 @@
+package com.bikeshare.app.domain.update
+
+data class UpdateInfo(
+    val latestVersion: String,
+    val releaseUrl: String,
+)

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -1,5 +1,7 @@
 package com.bikeshare.app.ui.navigation
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.DirectionsBike
@@ -12,6 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.res.stringResource
@@ -60,6 +63,26 @@ fun AppNavGraph(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
     val isAdmin by appViewModel.isAdmin.collectAsStateWithLifecycle(initialValue = false)
+    val updateInfo by appViewModel.updateInfo.collectAsStateWithLifecycle(initialValue = null)
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    LaunchedEffect(updateInfo) {
+        val info = updateInfo ?: return@LaunchedEffect
+        val result = snackbarHostState.showSnackbar(
+            message = context.getString(R.string.update_available, info.latestVersion),
+            actionLabel = context.getString(R.string.update_download),
+            withDismissAction = true,
+            duration = SnackbarDuration.Long,
+        )
+        if (result == SnackbarResult.ActionPerformed) {
+            context.startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(info.releaseUrl))
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            )
+        }
+        appViewModel.dismissUpdate()
+    }
 
     val baseNavItems = listOf(
         BottomNavItem(Screen.Map.route, { Icon(Icons.Default.Map, contentDescription = null) }, R.string.nav_map),
@@ -86,6 +109,7 @@ fun AppNavGraph(
     }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         bottomBar = {
             if (showBottomBar) {
                 NavigationBar {

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppViewModel.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bikeshare.app.domain.repository.RentalRepository
+import com.bikeshare.app.domain.update.UpdateChecker
+import com.bikeshare.app.domain.update.UpdateInfo
 import com.bikeshare.app.notification.FreeTimeNotificationScheduler
 import com.bikeshare.app.util.NetworkResult
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -18,10 +20,24 @@ import javax.inject.Inject
 class AppViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val rentalRepository: RentalRepository,
+    private val updateChecker: UpdateChecker,
 ) : ViewModel() {
 
     private val _isAdmin = MutableStateFlow(false)
     val isAdmin: StateFlow<Boolean> = _isAdmin.asStateFlow()
+
+    private val _updateInfo = MutableStateFlow<UpdateInfo?>(null)
+    val updateInfo: StateFlow<UpdateInfo?> = _updateInfo.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _updateInfo.value = updateChecker.checkForUpdate()
+        }
+    }
+
+    fun dismissUpdate() {
+        _updateInfo.value = null
+    }
 
     fun loadLimits() {
         viewModelScope.launch {

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -122,4 +122,8 @@
     <string name="admin_value">Hodnota: %1$s</string>
     <string name="admin_status">Stav: %1$s</string>
     <string name="admin_code_label">Kód: %1$s</string>
+
+    <!-- Update notification -->
+    <string name="update_available">Je dostupná nová verzia %1$s</string>
+    <string name="update_download">Stiahnuť</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -122,4 +122,8 @@
     <string name="admin_value">Номінал: %1$s</string>
     <string name="admin_status">Статус: %1$s</string>
     <string name="admin_code_label">Код: %1$s</string>
+
+    <!-- Update notification -->
+    <string name="update_available">Доступна нова версія %1$s</string>
+    <string name="update_download">Завантажити</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,4 +122,8 @@
     <string name="admin_value">Value: %1$s</string>
     <string name="admin_status">Status: %1$s</string>
     <string name="admin_code_label">Code: %1$s</string>
+
+    <!-- Update notification -->
+    <string name="update_available">New version %1$s available</string>
+    <string name="update_download">Download</string>
 </resources>


### PR DESCRIPTION
## Summary
Adds a simple in-app update checker since the app is distributed via APK only (not Google Play).

## How it works
1. On app startup, `AppViewModel` calls `UpdateChecker.checkForUpdate()`
2. Checker hits GitHub Releases API (\`api.github.com/repos/.../releases/latest\`)
3. If \`tag_name\` > \`BuildConfig.VERSION_NAME\` → snackbar appears with "Download" action
4. Tapping Download opens the GitHub release page in browser

## New files
- \`data/api/github/GitHubApiService.kt\` — Retrofit interface using @Url for full URL
- \`data/api/github/GitHubReleaseDto.kt\` — Moshi DTO
- \`domain/update/UpdateChecker.kt\` — business logic (version compare, prerelease/draft filtering)
- \`domain/update/UpdateInfo.kt\` — UI data class
- \`di/GitHubModule.kt\` — separate Retrofit/OkHttp (no auth interceptor for public GitHub API)

## Configuration
\`UPDATE_CHECK_URL\` build-time prop (defaults to official repo). Set to empty string to disable.

## i18n
- EN: "New version %s available" / "Download"
- UK: "Доступна нова версія %s" / "Завантажити"
- SK: "Je dostupná nová verzia %s" / "Stiahnuť"

## Notes
- Draft and prerelease tags are skipped
- Network failures are silent (no error popup)
- Check runs once per AppViewModel lifecycle (app session)
- Rate limit: GitHub allows 60 req/hour per IP unauthenticated — one check per session is well below this