### PR TITLE
fix: use Google Code Scanner for QR (fixes ANDROID-6 crash)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,6 +129,7 @@ dependencies {
     implementation(libs.camerax.lifecycle)
     implementation(libs.camerax.view)
     implementation(libs.mlkit.barcode)
+    implementation(libs.play.services.code.scanner)
 
     // Storage
     implementation(libs.datastore.preferences)

--- a/app/src/main/java/com/bikeshare/app/ui/scanner/QrScannerScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/scanner/QrScannerScreen.kt
@@ -1,42 +1,40 @@
 package com.bikeshare.app.ui.scanner
 
-import android.Manifest
-import android.content.pm.PackageManager
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.camera.core.CameraSelector
-import androidx.camera.core.ImageAnalysis
-import androidx.camera.core.ImageProxy
-import androidx.camera.core.Preview
-import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.view.PreviewView
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.BlendMode
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.bikeshare.app.R
-import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.mlkit.vision.barcode.common.Barcode
-import com.google.mlkit.vision.common.InputImage
-import java.util.concurrent.Executors
+import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
+import timber.log.Timber
 
+/**
+ * QR scan entry point. Uses Google Code Scanner (bundled with Play Services)
+ * which launches a system-maintained full-screen scanner UI — no camera permission
+ * required, no in-app camera preview. Much more reliable than the previous custom
+ * CameraX + ML Kit implementation.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QrScannerScreen(
@@ -44,177 +42,66 @@ fun QrScannerScreen(
     onQrDetected: (String) -> Unit,
 ) {
     val context = LocalContext.current
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    var hasCameraPermission by remember {
-        mutableStateOf(
-            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
-                PackageManager.PERMISSION_GRANTED,
-        )
-    }
-
-    val permissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission(),
-    ) { granted ->
-        hasCameraPermission = granted
-    }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) {
-        if (!hasCameraPermission) {
-            permissionLauncher.launch(Manifest.permission.CAMERA)
-        }
-    }
+        val options = GmsBarcodeScannerOptions.Builder()
+            .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+            .enableAutoZoom()
+            .build()
 
-    var codeDetected by remember { mutableStateOf(false) }
-
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.qr_scan)) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
-                    }
-                },
-            )
-        },
-    ) { padding ->
-        if (hasCameraPermission) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding),
-            ) {
-                AndroidView(
-                    factory = { ctx ->
-                        val previewView = PreviewView(ctx)
-                        val cameraProviderFuture = ProcessCameraProvider.getInstance(ctx)
-                        val executor = Executors.newSingleThreadExecutor()
-
-                        cameraProviderFuture.addListener({
-                            val cameraProvider = cameraProviderFuture.get()
-
-                            val preview = Preview.Builder().build().also {
-                                it.surfaceProvider = previewView.surfaceProvider
-                            }
-
-                            val barcodeScanner = BarcodeScanning.getClient()
-
-                            val imageAnalysis = ImageAnalysis.Builder()
-                                .setResolutionSelector(
-                                    androidx.camera.core.resolutionselector.ResolutionSelector.Builder()
-                                        .setAspectRatioStrategy(
-                                            androidx.camera.core.resolutionselector.AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY
-                                        )
-                                        .build()
-                                )
-                                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                                .build()
-                                .also { analysis ->
-                                    analysis.setAnalyzer(executor) { imageProxy ->
-                                        processImage(imageProxy, barcodeScanner) { code ->
-                                            if (!codeDetected) {
-                                                codeDetected = true
-                                                onQrDetected(code)
-                                            }
-                                        }
-                                    }
-                                }
-
-                            cameraProvider.unbindAll()
-                            cameraProvider.bindToLifecycle(
-                                lifecycleOwner,
-                                CameraSelector.DEFAULT_BACK_CAMERA,
-                                preview,
-                                imageAnalysis,
-                            )
-                        }, ContextCompat.getMainExecutor(ctx))
-
-                        previewView
-                    },
-                    modifier = Modifier.fillMaxSize(),
-                )
-
-                // Semi-transparent overlay with scanning frame
-                ScanOverlay()
-
-                Text(
-                    text = stringResource(R.string.qr_scan_instruction),
-                    color = Color.White,
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 48.dp),
-                )
-            }
-        } else {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(text = stringResource(R.string.qr_scan_instruction))
-            }
-        }
-    }
-}
-
-@Composable
-private fun ScanOverlay() {
-    Canvas(modifier = Modifier.fillMaxSize()) {
-        val frameSize = size.minDimension * 0.65f
-        val left = (size.width - frameSize) / 2
-        val top = (size.height - frameSize) / 2
-        val frameRect = Rect(left, top, left + frameSize, top + frameSize)
-
-        // Semi-transparent background
-        val overlayPath = Path().apply {
-            addRect(Rect(0f, 0f, size.width, size.height))
-        }
-        val cutoutPath = Path().apply {
-            addRoundRect(
-                androidx.compose.ui.geometry.RoundRect(
-                    frameRect,
-                    CornerRadius(16.dp.toPx()),
-                ),
-            )
-        }
-        drawPath(overlayPath, Color.Black.copy(alpha = 0.5f))
-        drawPath(cutoutPath, Color.Transparent, blendMode = BlendMode.Clear)
-
-        // Scanning frame border
-        drawRoundRect(
-            color = Color.White,
-            topLeft = Offset(frameRect.left, frameRect.top),
-            size = androidx.compose.ui.geometry.Size(frameRect.width, frameRect.height),
-            cornerRadius = CornerRadius(16.dp.toPx()),
-            style = Stroke(width = 3.dp.toPx()),
-        )
-    }
-}
-
-@androidx.annotation.OptIn(androidx.camera.core.ExperimentalGetImage::class)
-private fun processImage(
-    imageProxy: ImageProxy,
-    scanner: com.google.mlkit.vision.barcode.BarcodeScanner,
-    onCodeFound: (String) -> Unit,
-) {
-    val mediaImage = imageProxy.image
-    if (mediaImage == null) {
-        imageProxy.close()
-        return
-    }
-    val inputImage = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
-    scanner.process(inputImage)
-        .addOnSuccessListener { barcodes ->
-            for (barcode in barcodes) {
-                if (barcode.format == Barcode.FORMAT_QR_CODE) {
-                    barcode.rawValue?.let { onCodeFound(it) }
+        GmsBarcodeScanning.getClient(context, options)
+            .startScan()
+            .addOnSuccessListener { barcode ->
+                val value = barcode.rawValue
+                if (value != null) {
+                    onQrDetected(value)
+                } else {
+                    onBack()
                 }
             }
+            .addOnCanceledListener {
+                onBack()
+            }
+            .addOnFailureListener { e ->
+                Timber.e(e, "QR scanner failed")
+                if (e is com.google.android.gms.common.api.ApiException &&
+                    e.statusCode == CommonStatusCodes.CANCELED
+                ) {
+                    onBack()
+                } else {
+                    errorMessage = e.message ?: context.getString(R.string.qr_scan_instruction)
+                }
+            }
+    }
+
+    Scaffold { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentAlignment = Alignment.Center,
+        ) {
+            val error = errorMessage
+            if (error == null) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(48.dp))
+                    Text(
+                        text = stringResource(R.string.qr_scan),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(top = 16.dp),
+                    )
+                }
+            } else {
+                Text(
+                    text = error,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
         }
-        .addOnCompleteListener {
-            imageProxy.close()
-        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ osmdroid = "6.1.20"
 playServicesLocation = "21.3.0"
 camerax = "1.4.1"
 mlkitBarcode = "17.3.0"
+codeScanner = "16.1.0"
 datastore = "1.1.1"
 securityCrypto = "1.1.0-alpha06"
 coil = "2.7.0"
@@ -71,6 +72,7 @@ camerax-camera2 = { group = "androidx.camera", name = "camera-camera2", version.
 camerax-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
 camerax-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
 mlkit-barcode = { group = "com.google.mlkit", name = "barcode-scanning", version.ref = "mlkitBarcode" }
+play-services-code-scanner = { group = "com.google.android.gms", name = "play-services-code-scanner", version.ref = "codeScanner" }
 
 # Storage
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }


### PR DESCRIPTION
## Summary
Switch from custom CameraX + ML Kit BarcodeScanning to the Google Code Scanner API (\`GmsBarcodeScanning\`), which launches a system-maintained full-screen scanner.

## Fixes
[ANDROID-6](https://whitebikes.sentry.io/issues/ANDROID-6) — \`NullPointerException\` at \`QrScannerScreen.kt:101\` when calling \`BarcodeScanning.getClient()\` on Android 16 / Pixel 7.

Sentry stack (deobfuscated thanks to the mapping upload from PR #32):
\`\`\`
at QrScannerScreen.kt:101
    val barcodeScanner = BarcodeScanning.getClient()
at com.google.mlkit.vision.barcode.BarcodeScanning.getClient
    (play-services-mlkit-barcode-scanning@18.3.1:1)
\`\`\`

## Changes
- Added \`com.google.android.gms:play-services-code-scanner:16.1.0\`
- \`QrScannerScreen.kt\` rewritten: now just calls \`GmsBarcodeScanning.getClient(context, options).startScan()\` in \`LaunchedEffect\` and handles success/cancel/failure
- Kept old dependencies (CameraX, mlkit-barcode) for now — can remove in follow-up once confirmed stable

## Benefits
- **Crash eliminated** — Code Scanner has its own lifecycle and doesn't crash on initialization
- **No in-app camera permission** needed (system manages it)
- **No custom preview/overlay** to maintain
- **Auto-zoom, torch** built-in
- Smaller code footprint: -193 / +83 lines

## Test plan
- [ ] Open QR scanner from Map — system UI appears
- [ ] Scan a valid bike QR → rent/return flow works as before
- [ ] Cancel scan (back button or X) → returns to previous screen
- [ ] Test on Pixel 7 / Android 16 — was crashing, should now work