### PR TITLE
feat: check for updates on every app resume, throttled to 24h

### DIFF
--- a/app/src/main/java/com/bikeshare/app/domain/update/UpdateChecker.kt
+++ b/app/src/main/java/com/bikeshare/app/domain/update/UpdateChecker.kt
@@ -1,21 +1,36 @@
 package com.bikeshare.app.domain.update
 
+import android.content.Context
+import android.content.SharedPreferences
 import com.bikeshare.app.BuildConfig
 import com.bikeshare.app.data.api.github.GitHubApiService
+import dagger.hilt.android.qualifiers.ApplicationContext
 import timber.log.Timber
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class UpdateChecker @Inject constructor(
+    @ApplicationContext context: Context,
     private val api: GitHubApiService,
 ) {
-    suspend fun checkForUpdate(): UpdateInfo? {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * @param force bypass the 24h throttle (useful for testing / manual triggers)
+     */
+    suspend fun checkForUpdate(force: Boolean = false): UpdateInfo? {
         if (BuildConfig.UPDATE_CHECK_URL.isBlank()) return null
+
+        if (!force && !shouldCheckNow()) return null
 
         val release = runCatching { api.getLatestRelease(BuildConfig.UPDATE_CHECK_URL) }
             .getOrNull()?.takeIf { it.isSuccessful }?.body()
             ?: return null
+
+        prefs.edit().putLong(KEY_LAST_CHECK, System.currentTimeMillis()).apply()
 
         if (release.draft || release.prerelease) return null
 
@@ -30,6 +45,11 @@ class UpdateChecker @Inject constructor(
         }
     }
 
+    private fun shouldCheckNow(): Boolean {
+        val lastCheck = prefs.getLong(KEY_LAST_CHECK, 0L)
+        return System.currentTimeMillis() - lastCheck >= CHECK_INTERVAL_MILLIS
+    }
+
     private fun isNewer(latest: String, current: String): Boolean {
         val l = latest.split('.').mapNotNull { it.toIntOrNull() }
         val c = current.split('.').mapNotNull { it.toIntOrNull() }
@@ -39,5 +59,11 @@ class UpdateChecker @Inject constructor(
             if (a != b) return a > b
         }
         return false
+    }
+
+    companion object {
+        private const val PREFS_NAME = "update_checker"
+        private const val KEY_LAST_CHECK = "last_check_millis"
+        private val CHECK_INTERVAL_MILLIS = TimeUnit.HOURS.toMillis(24)
     }
 }

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -10,11 +10,15 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.res.stringResource
@@ -69,6 +73,17 @@ fun AppNavGraph(
     val updateInfo by appViewModel.updateInfo.collectAsStateWithLifecycle(initialValue = null)
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_START) {
+                appViewModel.checkForUpdate()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     LaunchedEffect(navigateTo) {
         when (navigateTo) {

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppViewModel.kt
@@ -29,9 +29,10 @@ class AppViewModel @Inject constructor(
     private val _updateInfo = MutableStateFlow<UpdateInfo?>(null)
     val updateInfo: StateFlow<UpdateInfo?> = _updateInfo.asStateFlow()
 
-    init {
+    fun checkForUpdate() {
         viewModelScope.launch {
-            _updateInfo.value = updateChecker.checkForUpdate()
+            val info = updateChecker.checkForUpdate() ?: return@launch
+            _updateInfo.value = info
         }
     }
 


### PR DESCRIPTION
## Summary
Fix: users whose app process stayed alive in the background never saw notifications about new releases, because the update check ran only once in \`AppViewModel.init\`.

## Changes
- \`AppNavGraph\` adds a \`Lifecycle.Event.ON_START\` observer that calls \`appViewModel.checkForUpdate()\` every time the app comes to foreground
- \`UpdateChecker\` now throttles GitHub API calls to **at most once per 24 hours** via SharedPreferences (\`last_check_millis\`)
- \`checkForUpdate()\` has a \`force\` parameter for testing

## Behavior
| Scenario | Before | After |
|---|---|---|
| Fresh install | Check runs on first open | Check runs on first ON_START |
| User force-closes and reopens | Check runs | Check runs (if >24h) |
| User backgrounds & foregrounds | **No check** | Check runs (if >24h) |
| App alive for days | **Never checks again** | Checks every resume after 24h |

GitHub API rate limit (60 req/hour per IP unauthenticated) — one check per 24h per user is well under it.

## Test plan
- [ ] Install 1.0.2 → open → snackbar for 1.0.3 appears
- [ ] Dismiss snackbar → background app → foreground within 24h → no re-check
- [ ] Clear app data (resets SharedPreferences) → open → check runs immediately