### PR TITLE
fix: add ProGuard rules for ML Kit (fixes QR scanner crash)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -27,3 +27,12 @@
 
 # Sentry
 -dontwarn io.sentry.**
+
+# ML Kit + Google Code Scanner (reflection-based component registrars)
+-keep class com.google.mlkit.** { *; }
+-keep class com.google.android.gms.internal.mlkit_** { *; }
+-keep class com.google.android.gms.vision.** { *; }
+-keep class com.google.firebase.components.** { *; }
+-keepclassmembers class com.google.mlkit.** {
+    <init>(...);
+}


### PR DESCRIPTION
## Root cause
Verified locally on the same Pixel 7 / Android 16 device that was crashing. The crashes in \`ANDROID-5\`, \`ANDROID-6\`, \`ANDROID-7\` all had the same underlying cause.

**R8 was stripping the no-arg constructors of ML Kit's internal component registrars**:
- \`com.google.mlkit.common.internal.CommonComponentRegistrar\`
- \`com.google.mlkit.vision.barcode.internal.BarcodeRegistrar\`
- \`com.google.mlkit.vision.common.internal.VisionCommonRegistrar\`

ML Kit instantiates these via reflection, so R8 doesn't see them being used and removes the zero-arg constructors. Visible in logcat right before the NPE:

\`\`\`
W ComponentDiscovery: Could not instantiate CommonComponentRegistrar
Caused by: java.lang.NoSuchMethodException: CommonComponentRegistrar.<init> []
\`\`\`

This explains why only some users were hitting it — anyone tapping the QR scanner in a release (minified) build would crash. It also explains why switching from CameraX+MLKit to GmsBarcodeScanning in 1.0.3 didn't help: both paths share the same ComponentDiscovery.

## Fix
Add keep rules for ML Kit in \`app/proguard-rules.pro\`:

\`\`\`
-keep class com.google.mlkit.** { *; }
-keep class com.google.android.gms.internal.mlkit_** { *; }
-keep class com.google.android.gms.vision.** { *; }
-keep class com.google.firebase.components.** { *; }
-keepclassmembers class com.google.mlkit.** {
    <init>(...);
}
\`\`\`

## Verification
- Built debug APK with minification enabled (simulates release R8 pipeline)
- Installed on Pixel 7 running Android 16 (same device that was reporting crashes)
- Opened QR scanner → system scanner launched cleanly
- Closed scanner → returned to app without crash
- No \`ComponentDiscovery\` warnings in logcat, no \`NullPointerException\`