### PR TITLE
fix: make update snackbar persistent + show version on login

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,12 +30,15 @@ android {
         val sentryDsn = (project.findProperty("SENTRY_DSN") as? String)?.takeIf { it.isNotBlank() } ?: ""
         val updateCheckUrl = (project.findProperty("UPDATE_CHECK_URL") as? String)?.takeIf { it.isNotBlank() }
             ?: "https://api.github.com/repos/cyklokoalicia/OpenSourceBikeShare-Android/releases/latest"
+        val websiteUrl = (project.findProperty("WEBSITE_URL") as? String)?.takeIf { it.isNotBlank() }
+            ?: "https://whitebikes.info"
 
         buildConfigField("String", "API_BASE_URL", "\"$apiBaseUrl\"")
         buildConfigField("String", "APP_NAME", "\"$appName\"")
         buildConfigField("String", "LOGO_URL", "\"$logoUrl\"")
         buildConfigField("String", "SENTRY_DSN", "\"$sentryDsn\"")
         buildConfigField("String", "UPDATE_CHECK_URL", "\"$updateCheckUrl\"")
+        buildConfigField("String", "WEBSITE_URL", "\"$websiteUrl\"")
 
         resValue("string", "app_name", appName)
     }

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.1.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.1.1)" variant="fatal" version="9.1.1">
+
+</issues>

--- a/app/src/main/java/com/bikeshare/app/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/about/AboutScreen.kt
@@ -1,0 +1,248 @@
+package com.bikeshare.app.ui.about
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.SystemUpdate
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import coil.decode.SvgDecoder
+import coil.request.ImageRequest
+import com.bikeshare.app.BuildConfig
+import com.bikeshare.app.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutScreen(
+    onBack: () -> Unit,
+    viewModel: AboutViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.about_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            if (BuildConfig.LOGO_URL.isNotBlank()) {
+                AsyncImage(
+                    model = ImageRequest.Builder(context)
+                        .data(BuildConfig.LOGO_URL)
+                        .decoderFactory(SvgDecoder.Factory())
+                        .build(),
+                    contentDescription = null,
+                    modifier = Modifier.size(96.dp),
+                    contentScale = ContentScale.Fit,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            Text(
+                text = BuildConfig.APP_NAME,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(
+                    R.string.about_version,
+                    BuildConfig.VERSION_NAME,
+                    BuildConfig.VERSION_CODE,
+                ),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            UpdateStatusCard(
+                isChecking = uiState.isChecking,
+                updateInfo = uiState.updateInfo,
+                onDownload = { url -> openUrl(context, url) },
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            LinkCard(
+                icon = Icons.Default.Language,
+                title = stringResource(R.string.about_website),
+                subtitle = BuildConfig.WEBSITE_URL,
+                onClick = { openUrl(context, BuildConfig.WEBSITE_URL) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun UpdateStatusCard(
+    isChecking: Boolean,
+    updateInfo: com.bikeshare.app.domain.update.UpdateInfo?,
+    onDownload: (String) -> Unit,
+) {
+    when {
+        isChecking -> {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                    Spacer(modifier = Modifier.size(16.dp))
+                    Text(stringResource(R.string.about_checking_update))
+                }
+            }
+        }
+        updateInfo != null -> {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                ),
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Default.SystemUpdate,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                        Spacer(modifier = Modifier.size(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                stringResource(R.string.update_available, updateInfo.latestVersion),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Button(
+                        onClick = { onDownload(updateInfo.releaseUrl) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(stringResource(R.string.update_download))
+                    }
+                }
+            }
+        }
+        else -> {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        Icons.Default.CheckCircle,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Spacer(modifier = Modifier.size(12.dp))
+                    Text(stringResource(R.string.about_up_to_date))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LinkCard(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+            Spacer(modifier = Modifier.size(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(title, style = MaterialTheme.typography.titleMedium)
+                Text(
+                    subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                Icons.AutoMirrored.Filled.OpenInNew,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun openUrl(context: android.content.Context, url: String) {
+    context.startActivity(
+        Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+    )
+}

--- a/app/src/main/java/com/bikeshare/app/ui/about/AboutViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/about/AboutViewModel.kt
@@ -1,0 +1,39 @@
+package com.bikeshare.app.ui.about
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bikeshare.app.domain.update.UpdateChecker
+import com.bikeshare.app.domain.update.UpdateInfo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class AboutUiState(
+    val updateInfo: UpdateInfo? = null,
+    val isChecking: Boolean = false,
+)
+
+@HiltViewModel
+class AboutViewModel @Inject constructor(
+    private val updateChecker: UpdateChecker,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AboutUiState())
+    val uiState: StateFlow<AboutUiState> = _uiState.asStateFlow()
+
+    init {
+        checkForUpdate()
+    }
+
+    fun checkForUpdate() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isChecking = true)
+            // force = true: bypass the 24h throttle so user sees fresh result on demand
+            val info = updateChecker.checkForUpdate(force = true)
+            _uiState.value = AboutUiState(updateInfo = info, isChecking = false)
+        }
+    }
+}

--- a/app/src/main/java/com/bikeshare/app/ui/auth/LoginScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/auth/LoginScreen.kt
@@ -43,6 +43,7 @@ fun LoginScreen(
         }
     }
 
+    Box(modifier = Modifier.fillMaxSize()) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -139,5 +140,15 @@ fun LoginScreen(
                 )
             }
         }
+    }
+
+        Text(
+            text = "v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 16.dp),
+        )
     }
 }

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -37,6 +37,7 @@ import com.bikeshare.app.ui.auth.PhoneVerifyScreen
 import com.bikeshare.app.ui.auth.RegisterScreen
 import com.bikeshare.app.ui.map.MapScreen
 import com.bikeshare.app.ui.rental.RentalScreen
+import com.bikeshare.app.ui.about.AboutScreen
 import com.bikeshare.app.ui.profile.ProfileScreen
 import com.bikeshare.app.ui.credit.CreditScreen
 import com.bikeshare.app.ui.credithistory.CreditHistoryScreen
@@ -102,13 +103,19 @@ fun AppNavGraph(
         }
     }
 
+    val updateAvailableMessage = updateInfo?.let {
+        stringResource(R.string.update_available, it.latestVersion)
+    }
+    val updateDownloadLabel = stringResource(R.string.update_download)
+
     LaunchedEffect(updateInfo) {
         val info = updateInfo ?: return@LaunchedEffect
+        val message = updateAvailableMessage ?: return@LaunchedEffect
         val result = snackbarHostState.showSnackbar(
-            message = context.getString(R.string.update_available, info.latestVersion),
-            actionLabel = context.getString(R.string.update_download),
+            message = message,
+            actionLabel = updateDownloadLabel,
             withDismissAction = true,
-            duration = SnackbarDuration.Long,
+            duration = SnackbarDuration.Indefinite,
         )
         if (result == SnackbarResult.ActionPerformed) {
             context.startActivity(
@@ -215,6 +222,7 @@ fun AppNavGraph(
                     onNavigateToCredit = { navController.navigate(Screen.Credit.route) },
                     onNavigateToCreditHistory = { navController.navigate(Screen.CreditHistory.route) },
                     onNavigateToTrips = { navController.navigate(Screen.Trips.route) },
+                    onNavigateToAbout = { navController.navigate(Screen.About.route) },
                     onLogout = {
                         navController.navigate(Screen.Login.route) {
                             popUpTo(0) { inclusive = true }
@@ -233,6 +241,10 @@ fun AppNavGraph(
 
             composable(Screen.Trips.route) {
                 TripsScreen(onBack = { navController.popBackStack() })
+            }
+
+            composable(Screen.About.route) {
+                AboutScreen(onBack = { navController.popBackStack() })
             }
 
             composable(Screen.QrScanner.route) {

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/Screen.kt
@@ -11,6 +11,7 @@ sealed class Screen(val route: String) {
     data object CreditHistory : Screen("credit_history")
     data object Trips : Screen("trips")
     data object QrScanner : Screen("qr_scanner")
+    data object About : Screen("about")
 
     // Admin
     data object AdminDashboard : Screen("admin/dashboard")

--- a/app/src/main/java/com/bikeshare/app/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/profile/ProfileScreen.kt
@@ -22,6 +22,7 @@ fun ProfileScreen(
     onNavigateToCredit: () -> Unit,
     onNavigateToCreditHistory: () -> Unit,
     onNavigateToTrips: () -> Unit,
+    onNavigateToAbout: () -> Unit,
     onLogout: () -> Unit,
     viewModel: ProfileViewModel = hiltViewModel(),
 ) {
@@ -143,6 +144,15 @@ fun ProfileScreen(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.recent_trips))
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedButton(
+                onClick = onNavigateToAbout,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.about_menu))
             }
 
             if (uiState.isLoading) {

--- a/app/src/main/java/com/bikeshare/app/ui/scanner/QrScannerScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/scanner/QrScannerScreen.kt
@@ -42,6 +42,7 @@ fun QrScannerScreen(
     onQrDetected: (String) -> Unit,
 ) {
     val context = LocalContext.current
+    val fallbackErrorMessage = stringResource(R.string.qr_scan_instruction)
     var errorMessage by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) {
@@ -70,7 +71,7 @@ fun QrScannerScreen(
                 ) {
                     onBack()
                 } else {
-                    errorMessage = e.message ?: context.getString(R.string.qr_scan_instruction)
+                    errorMessage = e.message ?: fallbackErrorMessage
                 }
             }
     }

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -126,4 +126,12 @@
     <!-- Update notification -->
     <string name="update_available">Je dostupná nová verzia %1$s</string>
     <string name="update_download">Stiahnuť</string>
+
+    <!-- About screen -->
+    <string name="about_title">O aplikácii</string>
+    <string name="about_menu">O aplikácii</string>
+    <string name="about_version">Verzia %1$s (%2$d)</string>
+    <string name="about_website">Webstránka</string>
+    <string name="about_checking_update">Kontroluje sa aktualizácia…</string>
+    <string name="about_up_to_date">Máte najnovšiu verziu</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -126,4 +126,12 @@
     <!-- Update notification -->
     <string name="update_available">Доступна нова версія %1$s</string>
     <string name="update_download">Завантажити</string>
+
+    <!-- About screen -->
+    <string name="about_title">Про додаток</string>
+    <string name="about_menu">Про додаток</string>
+    <string name="about_version">Версія %1$s (%2$d)</string>
+    <string name="about_website">Веб-сайт</string>
+    <string name="about_checking_update">Перевірка оновлень…</string>
+    <string name="about_up_to_date">У вас остання версія</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,4 +126,12 @@
     <!-- Update notification -->
     <string name="update_available">New version %1$s available</string>
     <string name="update_download">Download</string>
+
+    <!-- About screen -->
+    <string name="about_title">About</string>
+    <string name="about_menu">About</string>
+    <string name="about_version">Version %1$s (%2$d)</string>
+    <string name="about_website">Website</string>
+    <string name="about_checking_update">Checking for updates…</string>
+    <string name="about_up_to_date">You have the latest version</string>
 </resources>


### PR DESCRIPTION
## Summary
Three improvements based on user feedback:

### 1. Update snackbar was disappearing too fast
User reported: "this notification disappears very quickly, can't see it". Previously `SnackbarDuration.Long` = ~10s.

**Fix:** Changed to `SnackbarDuration.Indefinite`. Stays visible until the user taps **Download** (opens release page) or **X** (dismiss).

### 2. Show current app version on Login screen
Added `v1.0.x (N)` at the bottom of LoginScreen so users can see which version they're running without digging through Android Settings.

### 3. New About screen (Profile → About)
- Logo + app name + version
- **Update status card**: live check on open
  - "Checking for updates…" → spinner
  - If newer version on GitHub: "Update available X.X.X" with a **Download** button (opens release page)
  - Otherwise: "You have the latest version" with a checkmark
  - Force-refreshes (bypasses UpdateChecker's 24h throttle) so users get a fresh answer on demand
- Website link (opens browser)

### Build config
New `WEBSITE_URL` build-time property (default `https://whitebikes.info`).

### i18n
All new strings translated for EN, UK, SK.

## Test plan
- [x] Login screen shows version at the bottom
- [x] Update snackbar stays visible until user interacts
- [x] About screen shows "Checking…" then either "Update available" card with working Download button or "Up to date"
- [x] Website link opens browser