### PR TITLE
fix: downgrade QR scanner failures from error to warning (ANDROID-A)

### DIFF
--- a/app/src/main/java/com/bikeshare/app/ui/scanner/QrScannerScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/scanner/QrScannerScreen.kt
@@ -65,12 +65,16 @@ fun QrScannerScreen(
                 onBack()
             }
             .addOnFailureListener { e ->
-                Timber.e(e, "QR scanner failed")
-                if (e is com.google.android.gms.common.api.ApiException &&
+                val isUserCancel = e is com.google.android.gms.common.api.ApiException &&
                     e.statusCode == CommonStatusCodes.CANCELED
-                ) {
+                if (isUserCancel) {
+                    // Expected: user closed the system scanner. No log.
                     onBack()
                 } else {
+                    // Scanner failed in an expected way (MLKit init, module not installed,
+                    // camera unavailable, etc.). Don't spam Sentry with errors — warn and
+                    // show the user a friendly message instead.
+                    Timber.w(e, "QR scanner failed")
                     errorMessage = e.message ?: fallbackErrorMessage
                 }
             }


### PR DESCRIPTION
## Summary
Sentry issue **ANDROID-A** (\`MlKitException: Failed to scan code\`) was being raised on normal QR scanner failure paths — user closed the scanner without scanning, MLKit module wasn't installed yet, camera temporarily unavailable, etc. None of these are real app bugs, but \`Timber.e()\` was sending them as errors to Sentry.

## Changes
- User-cancelled scans (\`CommonStatusCodes.CANCELED\`) are no longer logged at all — expected behavior
- Other scanner failures use \`Timber.w\` instead of \`Timber.e\` — still visible in local debug builds, no longer flooding Sentry errors