### PR TITLE
fix: admin coupons — tap to copy, drop redundant status line

### DIFF
--- a/app/src/main/java/com/bikeshare/app/ui/admin/coupons/AdminCouponsScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/coupons/AdminCouponsScreen.kt
@@ -1,21 +1,29 @@
 package com.bikeshare.app.ui.admin.coupons
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Sell
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.content.getSystemService
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bikeshare.app.R
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -26,6 +34,9 @@ fun AdminCouponsScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     var showGenerateDialog by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val copiedMessage = stringResource(R.string.admin_coupon_copied)
 
     LaunchedEffect(uiState.message) { uiState.message?.let { snackbarHostState.showSnackbar(it) } }
     LaunchedEffect(uiState.error) { uiState.error?.let { snackbarHostState.showSnackbar(it) } }
@@ -57,7 +68,14 @@ fun AdminCouponsScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     items(uiState.coupons) { coupon ->
-                        Card(modifier = Modifier.fillMaxWidth()) {
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    copyToClipboard(context, coupon.coupon)
+                                    scope.launch { snackbarHostState.showSnackbar(copiedMessage) }
+                                },
+                        ) {
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -65,11 +83,21 @@ fun AdminCouponsScreen(
                                 horizontalArrangement = Arrangement.SpaceBetween,
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                Column {
+                                Column(modifier = Modifier.weight(1f)) {
                                     Text(coupon.coupon, style = MaterialTheme.typography.titleMedium)
-                                    coupon.value?.let { Text(stringResource(R.string.admin_value, it.toString()), style = MaterialTheme.typography.bodySmall) }
-                                    coupon.status?.let { Text(stringResource(R.string.admin_status, it), style = MaterialTheme.typography.bodySmall) }
+                                    coupon.value?.let {
+                                        Text(
+                                            stringResource(R.string.admin_value, it.toString()),
+                                            style = MaterialTheme.typography.bodySmall,
+                                        )
+                                    }
                                 }
+                                Icon(
+                                    Icons.Default.ContentCopy,
+                                    contentDescription = stringResource(R.string.admin_coupon_copy),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
                                 IconButton(onClick = { viewModel.sellCoupon(coupon.coupon) }) {
                                     Icon(Icons.Default.Sell, contentDescription = stringResource(R.string.admin_mark_sold))
                                 }
@@ -105,4 +133,9 @@ fun AdminCouponsScreen(
             },
         )
     }
+}
+
+private fun copyToClipboard(context: Context, value: String) {
+    val clipboard = context.getSystemService<ClipboardManager>() ?: return
+    clipboard.setPrimaryClip(ClipData.newPlainText("coupon", value))
 }

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -132,6 +132,8 @@
     <string name="about_menu">O aplikácii</string>
     <string name="about_version">Verzia %1$s (%2$d)</string>
     <string name="about_website">Webstránka</string>
+    <string name="admin_coupon_copy">Kopírovať kód kupónu</string>
+    <string name="admin_coupon_copied">Kupón skopírovaný</string>
     <string name="about_checking_update">Kontroluje sa aktualizácia…</string>
     <string name="about_up_to_date">Máte najnovšiu verziu</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -132,6 +132,8 @@
     <string name="about_menu">Про додаток</string>
     <string name="about_version">Версія %1$s (%2$d)</string>
     <string name="about_website">Веб-сайт</string>
+    <string name="admin_coupon_copy">Скопіювати код купону</string>
+    <string name="admin_coupon_copied">Купон скопійовано</string>
     <string name="about_checking_update">Перевірка оновлень…</string>
     <string name="about_up_to_date">У вас остання версія</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,6 +132,8 @@
     <string name="about_menu">About</string>
     <string name="about_version">Version %1$s (%2$d)</string>
     <string name="about_website">Website</string>
+    <string name="admin_coupon_copy">Copy coupon code</string>
+    <string name="admin_coupon_copied">Coupon copied to clipboard</string>
     <string name="about_checking_update">Checking for updates…</string>
     <string name="about_up_to_date">You have the latest version</string>
 </resources>


### PR DESCRIPTION
## Summary
Two small admin-UX fixes reported by an operator using the coupons list:

1. **Coupon values weren't copyable.** Now tapping anywhere on a coupon card copies the code to the system clipboard and shows a snackbar "Coupon copied". A copy icon is added on each row as a visual cue.
2. **Redundant "Status: …" line removed.** The list only shows unsold coupons, so the status was always the same and just added noise.

## Changes
- \`AdminCouponsScreen.kt\` — added \`clickable { copyToClipboard + snackbar }\`, added \`ContentCopy\` icon, removed status Text
- Strings added for EN/UK/SK:
  - \`admin_coupon_copy\` — content description on the icon
  - \`admin_coupon_copied\` — snackbar text

## Test plan
- [ ] Tap coupon card → clipboard contains the code, snackbar appears
- [ ] "Sell" action icon still works (not swallowed by card click)
- [ ] No status line visible in the list