### PR TITLE
fix: ignore offline network exceptions in Sentry

### DIFF
--- a/app/src/main/java/com/bikeshare/app/BikeShareApp.kt
+++ b/app/src/main/java/com/bikeshare/app/BikeShareApp.kt
@@ -4,6 +4,9 @@ import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 import io.sentry.android.core.SentryAndroid
 import timber.log.Timber
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 
 @HiltAndroidApp
 class BikeShareApp : Application() {
@@ -22,6 +25,9 @@ class BikeShareApp : Application() {
                 options.tracesSampleRate = if (BuildConfig.DEBUG) 1.0 else 0.2
                 options.environment = if (BuildConfig.DEBUG) "development" else "production"
                 options.release = "${BuildConfig.APPLICATION_ID}@${BuildConfig.VERSION_NAME}"
+                options.addIgnoredExceptionForType(UnknownHostException::class.java)
+                options.addIgnoredExceptionForType(SocketTimeoutException::class.java)
+                options.addIgnoredExceptionForType(ConnectException::class.java)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Filter out `UnknownHostException`, `SocketTimeoutException`, and `ConnectException` in the Android Sentry SDK init.
- These are caused by the user's connectivity (no internet, DNS down, captive portal), not by the app, so they create noise and burn Sentry quota without being actionable.
- Implemented via `options.addIgnoredExceptionForType(...)` so events never leave the device.

## Test plan
- [ ] Build Debug & Release variants succeed
- [ ] Toggle airplane mode and trigger a network call → no new Sentry events appear in the dashboard
- [ ] A non-network crash still reports normally