### PR TITLE
chore: upgrade KSP to 2.3.7 for Kotlin 2.3 compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ junitExt = "1.3.0"
 espresso = "3.6.1"
 robolectric = "4.14.1"
 androidxTestCore = "1.7.0"
-ksp = "2.2.10-2.0.2"
+ksp = "2.3.7"
 
 [libraries]
 # AndroidX Core


### PR DESCRIPTION
## Summary

After bumping Kotlin to 2.3.21 (#41), KSP 2.2.10-2.0.2 emits build warnings on every compilation:

> ksp-2.2.10-2.0.2 is too old for kotlin-2.3.21. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.10.

## What changed

Bump KSP from 2.2.10-2.0.2 → 2.3.7 in \`gradle/libs.versions.toml\`.

## Note: KSP1 → KSP2 migration

This is a non-trivial version jump because KSP changed its versioning scheme and underlying architecture in 2.3.0:
- KSP1 (old \`<kotlin>-<ksp>\` format) is **deprecated**
- KSP2 (\`2.3.x\`) is no longer a Kotlin compiler plugin — it's a standalone tool built on stable compiler APIs
- Decoupled from a specific Kotlin compiler version

Project uses KSP for Hilt and Moshi codegen — both should work under KSP2, but want CI to confirm.

## Test plan

- [ ] CI: build passes
- [ ] CI: Analyze Kotlin passes
- [ ] No 'ksp too old' warnings in build log
- [ ] Hilt-generated code (DI graph) compiles
- [ ] Moshi-generated adapters compile and parse JSON in tests