### PR TITLE
feat(qr): fix silent stand scan + Android App Links via system camera

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -130,6 +130,28 @@ jobs:
           mv app/build/outputs/apk/release/app-release.apk \
              app/build/outputs/apk/release/WhiteBikes-${{ steps.version.outputs.version_name }}.apk
 
+      - name: Extract APK signing fingerprint
+        id: fingerprint
+        run: |
+          APK=$(ls app/build/outputs/apk/release/*.apk | head -1)
+          # apksigner ships in Android SDK build-tools (pre-installed on ubuntu-latest
+          # at $ANDROID_SDK_ROOT). It supports v1/v2/v3 signing schemes — keytool only
+          # reads v1 (META-INF/*.RSA), which modern AGP no longer emits by default.
+          APKSIGNER=$(ls "$ANDROID_SDK_ROOT"/build-tools/*/apksigner | sort -V | tail -1)
+          RAW=$("$APKSIGNER" verify --print-certs "$APK" \
+            | awk -F': ' '/Signer #1 certificate SHA-256 digest:/ {print $2; exit}')
+          if [ -z "$RAW" ]; then
+            echo "::error::Could not extract SHA-256 fingerprint from $APK"
+            exit 1
+          fi
+          # apksigner emits lowercase hex without separators (e.g. ab12...). Convert to
+          # the colon-separated uppercase form expected by assetlinks.json (AB:12:...).
+          FP=$(echo "$RAW" | tr 'a-f' 'A-F' | sed 's/\(..\)/\1:/g; s/:$//')
+          HOST=$(echo '${{ vars.API_BASE_URL }}' | sed -E 's|^https?://([^/]+).*|\1|')
+          echo "sha256=$FP" >> $GITHUB_OUTPUT
+          echo "assetlinks_url=https://$HOST/.well-known/assetlinks.json" >> $GITHUB_OUTPUT
+          echo "Release SHA-256: $FP"
+
       - name: Generate changelog
         id: changelog
         run: |
@@ -150,4 +172,11 @@ jobs:
           body: |
             ## Changes
             ${{ steps.changelog.outputs.changelog }}
+
+            ## App signing
+            **SHA-256:** `${{ steps.fingerprint.outputs.sha256 }}`
+
+            If you sideload this APK, verify the fingerprint matches the one published at
+            <${{ steps.fingerprint.outputs.assetlinks_url }}>. A match confirms the APK was
+            built and signed by the project's release key and has not been tampered with.
           files: app/build/outputs/apk/release/WhiteBikes-${{ steps.version.outputs.version_name }}.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.net.URI
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
@@ -39,6 +41,17 @@ android {
         buildConfigField("String", "SENTRY_DSN", "\"$sentryDsn\"")
         buildConfigField("String", "UPDATE_CHECK_URL", "\"$updateCheckUrl\"")
         buildConfigField("String", "WEBSITE_URL", "\"$websiteUrl\"")
+
+        // Host used in QR-code URLs (.../scan.php/rent/N, .../scan.php/return/X) — derived
+        // from API_BASE_URL so a deployment-specific build links to its own domain. Used as a
+        // manifest placeholder for the App Links intent-filter on MainActivity. Fail loudly
+        // on a malformed API_BASE_URL — silently falling back would ship an APK that
+        // registers handlers for the wrong domain.
+        val scanHost: String = runCatching { URI(apiBaseUrl).host }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: error("API_BASE_URL=\"$apiBaseUrl\" is malformed — cannot derive a host for App Links")
+        manifestPlaceholders["scanHost"] = scanHost
 
         resValue("string", "app_name", appName)
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,14 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="${scanHost}" />
+                <data android:pathPrefix="/scan.php/" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/app/src/main/java/com/bikeshare/app/MainActivity.kt
+++ b/app/src/main/java/com/bikeshare/app/MainActivity.kt
@@ -26,6 +26,7 @@ class MainActivity : ComponentActivity() {
     ) { }
 
     private var pendingNavigation by mutableStateOf<String?>(null)
+    private var pendingQrUrl by mutableStateOf<String?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,12 +38,18 @@ class MainActivity : ComponentActivity() {
                 requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         }
-        pendingNavigation = intent.getStringExtra(FreeTimeNotificationWorker.EXTRA_NAVIGATE_TO)
+        // Only consume on first launch — on configuration changes the same Intent is
+        // redelivered, which would cause deep-link QR actions (rent/return) to fire twice.
+        if (savedInstanceState == null) {
+            consumeIntent(intent)
+        }
         setContent {
             BikeShareTheme {
                 AppNavGraph(
                     navigateTo = pendingNavigation,
+                    pendingQrUrl = pendingQrUrl,
                     onNavigationConsumed = { pendingNavigation = null },
+                    onQrConsumed = { pendingQrUrl = null },
                 )
             }
         }
@@ -51,8 +58,15 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        consumeIntent(intent)
+    }
+
+    private fun consumeIntent(intent: Intent) {
         intent.getStringExtra(FreeTimeNotificationWorker.EXTRA_NAVIGATE_TO)?.let {
             pendingNavigation = it
+        }
+        if (intent.action == Intent.ACTION_VIEW) {
+            intent.dataString?.let { pendingQrUrl = it }
         }
     }
 }

--- a/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
@@ -96,25 +96,42 @@ fun MapScreen(
         }
     }
 
-    val qrAction = qrSavedStateHandle?.get<String>("qr_action")
-    val qrBikeNumber = qrSavedStateHandle?.get<Int>("qr_bike_number")
-    val qrStandName = qrSavedStateHandle?.get<String>("qr_stand_name")
-    val qrSnackbar = qrSavedStateHandle?.get<String>("snackbar")
-    LaunchedEffect(qrAction, qrBikeNumber, qrStandName, qrSnackbar) {
-        qrSnackbar?.let { msg ->
+    var pendingReturnStand by remember { mutableStateOf<String?>(null) }
+
+    // Reactive reads — SavedStateHandle.get() is not Compose-observable, so writes
+    // performed while MapScreen is already on screen (e.g. an https://.../scan.php/...
+    // App Link delivered via Intent.ACTION_VIEW) would otherwise be invisible to it.
+    val qrAction = qrSavedStateHandle
+        ?.getStateFlow<String?>("qr_action", null)
+        ?.collectAsStateWithLifecycle()
+        ?.value
+    val qrBikeNumber = qrSavedStateHandle
+        ?.getStateFlow<Int?>("qr_bike_number", null)
+        ?.collectAsStateWithLifecycle()
+        ?.value
+    val qrStandName = qrSavedStateHandle
+        ?.getStateFlow<String?>("qr_stand_name", null)
+        ?.collectAsStateWithLifecycle()
+        ?.value
+    val qrUnknownRaw = qrSavedStateHandle
+        ?.getStateFlow<String?>("qr_unknown_raw", null)
+        ?.collectAsStateWithLifecycle()
+        ?.value
+    val qrUnknownMessage = qrUnknownRaw?.let { stringResource(R.string.qr_unknown, it) }
+    LaunchedEffect(qrAction, qrBikeNumber, qrStandName, qrUnknownRaw) {
+        qrUnknownMessage?.let { msg ->
             snackbarHostState.showSnackbar(msg)
-            qrSavedStateHandle?.remove<String>("snackbar")
+            qrSavedStateHandle?.remove<String>("qr_unknown_raw")
         }
         if (qrAction == null) return@LaunchedEffect
         when (qrAction) {
             "rent" -> qrBikeNumber?.let { viewModel.rentBike(it) }
-            "return" -> {
-                val stand = qrStandName ?: return@LaunchedEffect
+            "return" -> qrStandName?.let { stand ->
                 val myBikes = uiState.myBikes
                 if (myBikes.size == 1) {
                     viewModel.returnBike(myBikes.first().bikeNum, stand)
                 } else {
-                    snackbarHostState.showSnackbar("Scanned stand: $stand. Return only when 1 bike is rented.")
+                    pendingReturnStand = stand
                 }
             }
         }
@@ -235,6 +252,54 @@ fun MapScreen(
                     },
                 )
             }
+        }
+
+        // Return-bike dialog when stand QR is scanned but auto-return is not possible
+        // (0 active rentals or 2+ active rentals — user picks which bike to return).
+        pendingReturnStand?.let { stand ->
+            val myBikes = uiState.myBikes
+            AlertDialog(
+                onDismissRequest = { pendingReturnStand = null },
+                title = { Text(stringResource(R.string.qr_return_dialog_title, stand)) },
+                text = {
+                    if (myBikes.isEmpty()) {
+                        Text(stringResource(R.string.qr_return_no_rental))
+                    } else {
+                        Column {
+                            Text(stringResource(R.string.qr_return_pick_prompt))
+                            Spacer(modifier = Modifier.height(8.dp))
+                            myBikes.forEach { bike ->
+                                TextButton(
+                                    onClick = {
+                                        viewModel.returnBike(bike.bikeNum, stand)
+                                        pendingReturnStand = null
+                                    },
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.bike_number, bike.bikeNum),
+                                        modifier = Modifier.fillMaxWidth(),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                },
+                confirmButton = {
+                    if (myBikes.isEmpty()) {
+                        TextButton(onClick = { pendingReturnStand = null }) {
+                            Text(stringResource(R.string.ok))
+                        }
+                    }
+                },
+                dismissButton = if (myBikes.isNotEmpty()) {
+                    {
+                        TextButton(onClick = { pendingReturnStand = null }) {
+                            Text(stringResource(R.string.cancel))
+                        }
+                    }
+                } else null,
+            )
         }
 
         // Rent code dialog (params only, no HTML)

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -65,7 +66,9 @@ data class BottomNavItem(
 fun AppNavGraph(
     appViewModel: AppViewModel = hiltViewModel(),
     navigateTo: String? = null,
+    pendingQrUrl: String? = null,
     onNavigationConsumed: () -> Unit = {},
+    onQrConsumed: () -> Unit = {},
 ) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -101,6 +104,31 @@ fun AppNavGraph(
             null -> Unit
             else -> onNavigationConsumed()
         }
+    }
+
+    // Deep-link arrives via Intent.ACTION_VIEW (e.g. user opened a /scan.php/... URL from
+    // the system camera). Apply it once the Map screen is reachable; keep waiting otherwise
+    // (e.g. user is on Login). Once Map is in the back stack we write the parsed result to
+    // its SavedStateHandle, which MapScreen consumes in the same way as in-app QR scans.
+    LaunchedEffect(pendingQrUrl, currentDestination?.route) {
+        val raw = pendingQrUrl ?: return@LaunchedEffect
+        val mapEntry = navController.currentBackStack.value.firstOrNull {
+            it.destination.route == Screen.Map.route
+        }
+        if (mapEntry == null) {
+            // Not authenticated yet — wait. Effect re-runs when destination changes.
+            return@LaunchedEffect
+        }
+        if (currentDestination?.route != Screen.Map.route) {
+            navController.navigate(Screen.Map.route) {
+                popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                launchSingleTop = true
+                restoreState = true
+            }
+            return@LaunchedEffect
+        }
+        applyQrResult(raw, mapEntry.savedStateHandle)
+        onQrConsumed()
     }
 
     val updateAvailableMessage = updateInfo?.let {
@@ -251,21 +279,8 @@ fun AppNavGraph(
                 QrScannerScreen(
                     onBack = { navController.popBackStack() },
                     onQrDetected = { code ->
-                        val mapEntry = navController.getBackStackEntry(Screen.Map.route)
-                        val handle = mapEntry.savedStateHandle
-                        when (val result = parseQrScanResult(code)) {
-                            is QrScanResult.Rent -> {
-                                handle?.set("qr_action", "rent")
-                                handle?.set("qr_bike_number", result.bikeNumber)
-                            }
-                            is QrScanResult.Return -> {
-                                handle?.set("qr_action", "return")
-                                handle?.set("qr_stand_name", result.standName)
-                            }
-                            QrScanResult.Unknown -> {
-                                handle?.set("snackbar", "Unknown QR: $code")
-                            }
-                        }
+                        val handle = navController.getBackStackEntry(Screen.Map.route).savedStateHandle
+                        applyQrResult(code, handle)
                         navController.popBackStack()
                     },
                 )
@@ -328,3 +343,26 @@ fun AppNavGraph(
         }
     }
 }
+
+internal fun applyQrResult(raw: String, handle: SavedStateHandle) {
+    // Clear any keys not produced by this dispatch so a prior unconsumed scan can't
+    // leak into the new one (e.g. an Unknown scan after a stale rent/return).
+    handle.remove<String>("qr_action")
+    handle.remove<Int>("qr_bike_number")
+    handle.remove<String>("qr_stand_name")
+    handle.remove<String>("qr_unknown_raw")
+    when (val result = parseQrScanResult(raw)) {
+        is QrScanResult.Rent -> {
+            handle["qr_action"] = "rent"
+            handle["qr_bike_number"] = result.bikeNumber
+        }
+        is QrScanResult.Return -> {
+            handle["qr_action"] = "return"
+            handle["qr_stand_name"] = result.standName
+        }
+        QrScanResult.Unknown -> {
+            handle["qr_unknown_raw"] = raw
+        }
+    }
+}
+

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -112,13 +112,11 @@ fun AppNavGraph(
     // its SavedStateHandle, which MapScreen consumes in the same way as in-app QR scans.
     LaunchedEffect(pendingQrUrl, currentDestination?.route) {
         val raw = pendingQrUrl ?: return@LaunchedEffect
-        val mapEntry = navController.currentBackStack.value.firstOrNull {
-            it.destination.route == Screen.Map.route
-        }
-        if (mapEntry == null) {
-            // Not authenticated yet — wait. Effect re-runs when destination changes.
-            return@LaunchedEffect
-        }
+        // getBackStackEntry throws IllegalArgumentException when Map isn't in the
+        // back stack yet (e.g. user is on Login). Treat that as "wait" — the effect
+        // re-runs on destination changes, so we'll retry once Map is reached.
+        val mapEntry = runCatching { navController.getBackStackEntry(Screen.Map.route) }
+            .getOrNull() ?: return@LaunchedEffect
         if (currentDestination?.route != Screen.Map.route) {
             navController.navigate(Screen.Map.route) {
                 popUpTo(navController.graph.findStartDestination().id) { saveState = true }

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -42,6 +42,10 @@
     <string name="rent_button">Požičať</string>
     <string name="qr_scan">Skenovať QR</string>
     <string name="qr_scan_instruction">Namierte kameru na QR kód na bicykli alebo stojane</string>
+    <string name="qr_return_dialog_title">Vrátiť na %1$s</string>
+    <string name="qr_return_no_rental">Nemáte žiadne požičané bicykle na vrátenie na tento stojan.</string>
+    <string name="qr_return_pick_prompt">Vyberte, ktorý bicykel vrátiť:</string>
+    <string name="qr_unknown">Neznámy QR kód: %1$s</string>
     <string name="my_location">Moja poloha</string>
     <string name="service_stand">Servis</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -42,6 +42,10 @@
     <string name="rent_button">Орендувати</string>
     <string name="qr_scan">Сканувати QR</string>
     <string name="qr_scan_instruction">Наведіть камеру на QR-код на велосипеді або стенді</string>
+    <string name="qr_return_dialog_title">Повернути на %1$s</string>
+    <string name="qr_return_no_rental">У вас немає орендованих велосипедів для повернення на цей стенд.</string>
+    <string name="qr_return_pick_prompt">Виберіть, який велосипед повернути:</string>
+    <string name="qr_unknown">Невідомий QR-код: %1$s</string>
     <string name="my_location">Моє місце</string>
     <string name="service_stand">Сервіс</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,10 @@
     <string name="rent_button">Rent</string>
     <string name="qr_scan">Scan QR</string>
     <string name="qr_scan_instruction">Point the camera at a QR code on a bike or stand</string>
+    <string name="qr_return_dialog_title">Return to %1$s</string>
+    <string name="qr_return_no_rental">You have no rented bikes to return at this stand.</string>
+    <string name="qr_return_pick_prompt">Choose which bike to return:</string>
+    <string name="qr_unknown">Unknown QR code: %1$s</string>
     <string name="my_location">My location</string>
     <string name="service_stand">Service</string>
 

--- a/app/src/test/java/com/bikeshare/app/ui/navigation/ApplyQrResultTest.kt
+++ b/app/src/test/java/com/bikeshare/app/ui/navigation/ApplyQrResultTest.kt
@@ -1,0 +1,57 @@
+package com.bikeshare.app.ui.navigation
+
+import androidx.lifecycle.SavedStateHandle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ApplyQrResultTest {
+
+    @Test
+    fun `rent URL writes qr_action and qr_bike_number to handle`() {
+        val handle = SavedStateHandle()
+        applyQrResult("https://whitebikes.info/scan.php/rent/42", handle)
+        assertEquals("rent", handle.get<String>("qr_action"))
+        assertEquals(42, handle.get<Int>("qr_bike_number"))
+        assertNull(handle.get<String>("qr_stand_name"))
+        assertNull(handle.get<String>("qr_unknown_raw"))
+    }
+
+    @Test
+    fun `return URL writes qr_action and qr_stand_name to handle`() {
+        val handle = SavedStateHandle()
+        applyQrResult("https://whitebikes.info/scan.php/return/MAIN", handle)
+        assertEquals("return", handle.get<String>("qr_action"))
+        assertEquals("MAIN", handle.get<String>("qr_stand_name"))
+        assertNull(handle.get<Int>("qr_bike_number"))
+        assertNull(handle.get<String>("qr_unknown_raw"))
+    }
+
+    @Test
+    fun `unknown QR writes raw value to qr_unknown_raw`() {
+        val handle = SavedStateHandle()
+        applyQrResult("https://example.com/something/else", handle)
+        assertEquals("https://example.com/something/else", handle.get<String>("qr_unknown_raw"))
+        assertNull(handle.get<String>("qr_action"))
+    }
+
+    @Test
+    fun `unknown QR clears any prior rent action left in the handle`() {
+        val handle = SavedStateHandle()
+        applyQrResult("https://whitebikes.info/scan.php/rent/42", handle)
+        applyQrResult("https://example.com/garbage", handle)
+        assertNull(handle.get<String>("qr_action"))
+        assertNull(handle.get<Int>("qr_bike_number"))
+        assertEquals("https://example.com/garbage", handle.get<String>("qr_unknown_raw"))
+    }
+
+    @Test
+    fun `rent QR clears any prior return action left in the handle`() {
+        val handle = SavedStateHandle()
+        applyQrResult("https://whitebikes.info/scan.php/return/MAIN", handle)
+        applyQrResult("https://whitebikes.info/scan.php/rent/7", handle)
+        assertEquals("rent", handle.get<String>("qr_action"))
+        assertEquals(7, handle.get<Int>("qr_bike_number"))
+        assertNull(handle.get<String>("qr_stand_name"))
+    }
+}

--- a/app/src/test/java/com/bikeshare/app/ui/scanner/QrScanResultTest.kt
+++ b/app/src/test/java/com/bikeshare/app/ui/scanner/QrScanResultTest.kt
@@ -1,0 +1,52 @@
+package com.bikeshare.app.ui.scanner
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QrScanResultTest {
+
+    @Test
+    fun `rent URL with absolute https scheme parses to Rent`() {
+        val result = parseQrScanResult("https://whitebikes.info/scan.php/rent/42")
+        assertEquals(QrScanResult.Rent(42), result)
+    }
+
+    @Test
+    fun `rent URL with trailing slash parses to Rent`() {
+        val result = parseQrScanResult("https://example.com/scan.php/rent/7/")
+        assertEquals(QrScanResult.Rent(7), result)
+    }
+
+    @Test
+    fun `return URL with stand name parses to Return`() {
+        val result = parseQrScanResult("https://whitebikes.info/scan.php/return/MAIN")
+        assertEquals(QrScanResult.Return("MAIN"), result)
+    }
+
+    @Test
+    fun `return URL with mixed-case stand name preserves case`() {
+        val result = parseQrScanResult("https://example.com/scan.php/return/Main-Square")
+        assertEquals(QrScanResult.Return("Main-Square"), result)
+    }
+
+    @Test
+    fun `bare digit string is treated as bike number`() {
+        val result = parseQrScanResult("123")
+        assertEquals(QrScanResult.Rent(123), result)
+    }
+
+    @Test
+    fun `empty string yields Unknown`() {
+        assertEquals(QrScanResult.Unknown, parseQrScanResult(""))
+    }
+
+    @Test
+    fun `unrelated URL yields Unknown`() {
+        assertEquals(QrScanResult.Unknown, parseQrScanResult("https://example.com/something/else"))
+    }
+
+    @Test
+    fun `whitespace around input is trimmed`() {
+        assertEquals(QrScanResult.Rent(5), parseQrScanResult("  https://x/rent/5  "))
+    }
+}


### PR DESCRIPTION
## Summary

- **Stand QR scan no longer silently fails** when the user has 0 or ≥2 active rentals. The 4s snackbar (which most users miss — hence "nothing happens" bug reports) is replaced with a Material 3 `AlertDialog`: empty-state message for 0 bikes, picker for ≥2 bikes. Single-rental flow is unchanged.
- **Android App Links** so the system camera offers/opens the BikeShare app for `https://{host}/scan.php/{rent,return}/...` URLs printed in stand/bike QR codes. The deployment host is derived from `API_BASE_URL` at build time (manifest placeholder `\${scanHost}`); a malformed `API_BASE_URL` now fails the build instead of silently falling back.
- **Reactive `SavedStateHandle` reads** in `MapScreen` so a deep link delivered while Map is already on screen is actually visible to it — the previous non-reactive `.get()` only worked for the in-app scanner because that flow re-composes Map.
- **`ACTION_VIEW` consumed only on first `onCreate`** — redelivered intents on rotation no longer trigger duplicate rent/return calls.
- **Release CI** extracts the signed APK's SHA-256 fingerprint via `apksigner` (supports v2/v3 schemes; `keytool` only reads v1) and embeds it in the GitHub release notes with a verification hint linking to `/.well-known/assetlinks.json`.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — 42 tests, all green (5 new for `parseQrScanResult` URL formats, 5 new for `applyQrResult` state writes/clearing, plus existing 32)
- [x] `./gradlew :app:assembleDebug -PAPI_BASE_URL=\"https://whitebikes.info/api/v1/\"` — APK builds, merged manifest contains intent-filter with `host=\"whitebikes.info\"` and `autoVerify=\"true\"`
- [x] Build correctly fails with a clear error on `-PAPI_BASE_URL=\"not-a-url\"`
- [x] Local fingerprint extraction (`apksigner verify --print-certs ...`) outputs the colon-separated uppercase form expected by `assetlinks.json`
- [ ] Manual: scan stand QR with 0 active rentals → dialog shows \"no rented bikes to return\" (was: fleeting snackbar)
- [ ] Manual: scan stand QR with 2 active rentals → bike-picker dialog
- [ ] Manual: \`adb shell am start -a android.intent.action.VIEW -d \"https://whitebikes.info/scan.php/return/MAIN\"\` → opens MainActivity, applies return flow
- [ ] After backend deploys assetlinks.json (cyklokoalicia/OpenSourceBikeShare#316): \`adb shell pm get-app-links com.bikeshare.app\` shows \`verified\` → camera-app QR scan opens BikeShare directly without chooser

## Companion PR

Backend assetlinks.json endpoint: cyklokoalicia/OpenSourceBikeShare#316