### PR TITLE
fix(update-check): distinguish failed checks from up-to-date

### DIFF
--- a/app/src/main/java/com/bikeshare/app/di/GitHubModule.kt
+++ b/app/src/main/java/com/bikeshare/app/di/GitHubModule.kt
@@ -1,5 +1,6 @@
 package com.bikeshare.app.di
 
+import com.bikeshare.app.BuildConfig
 import com.bikeshare.app.data.api.github.GitHubApiService
 import com.squareup.moshi.Moshi
 import dagger.Module
@@ -19,9 +20,22 @@ object GitHubModule {
     @Provides
     @Singleton
     fun provideGitHubApiService(moshi: Moshi): GitHubApiService {
+        // GitHub strongly recommends a meaningful User-Agent and applies stricter rate
+        // limits to anonymous calls without one. Accept header pins the API version so
+        // future GitHub-side schema changes don't surprise us.
+        val userAgent =
+            "${BuildConfig.APP_NAME}/${BuildConfig.VERSION_NAME} (${BuildConfig.APPLICATION_ID})"
         val client = OkHttpClient.Builder()
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(15, TimeUnit.SECONDS)
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("User-Agent", userAgent)
+                    .header("Accept", "application/vnd.github+json")
+                    .header("X-GitHub-Api-Version", "2022-11-28")
+                    .build()
+                chain.proceed(request)
+            }
             .build()
 
         return Retrofit.Builder()

--- a/app/src/main/java/com/bikeshare/app/domain/update/UpdateCheckResult.kt
+++ b/app/src/main/java/com/bikeshare/app/domain/update/UpdateCheckResult.kt
@@ -1,0 +1,14 @@
+package com.bikeshare.app.domain.update
+
+/**
+ * Outcome of an update check. Distinguishing [Failed] from [UpToDate] matters for
+ * UX — telling a user "you have the latest version" when the network call actually
+ * errored masks bugs and breeds distrust (the user keeps seeing "up to date" while
+ * everyone else got the new release).
+ */
+sealed interface UpdateCheckResult {
+    data class Available(val info: UpdateInfo) : UpdateCheckResult
+    data object UpToDate : UpdateCheckResult
+    data object Failed : UpdateCheckResult
+    data object Disabled : UpdateCheckResult
+}

--- a/app/src/main/java/com/bikeshare/app/domain/update/UpdateChecker.kt
+++ b/app/src/main/java/com/bikeshare/app/domain/update/UpdateChecker.kt
@@ -21,27 +21,38 @@ class UpdateChecker @Inject constructor(
     /**
      * @param force bypass the 24h throttle (useful for testing / manual triggers)
      */
-    suspend fun checkForUpdate(force: Boolean = false): UpdateInfo? {
-        if (BuildConfig.UPDATE_CHECK_URL.isBlank()) return null
+    suspend fun checkForUpdate(force: Boolean = false): UpdateCheckResult {
+        if (BuildConfig.UPDATE_CHECK_URL.isBlank()) return UpdateCheckResult.Disabled
 
-        if (!force && !shouldCheckNow()) return null
+        if (!force && !shouldCheckNow()) return UpdateCheckResult.UpToDate
 
-        val release = runCatching { api.getLatestRelease(BuildConfig.UPDATE_CHECK_URL) }
-            .getOrNull()?.takeIf { it.isSuccessful }?.body()
-            ?: return null
+        val response = runCatching { api.getLatestRelease(BuildConfig.UPDATE_CHECK_URL) }
+            .onFailure { Timber.w(it, "Update check threw — assuming Failed") }
+            .getOrNull()
+            ?: return UpdateCheckResult.Failed
+
+        if (!response.isSuccessful) {
+            Timber.w("Update check returned HTTP %d (rate limit / server error)", response.code())
+            return UpdateCheckResult.Failed
+        }
+        val release = response.body()
+        if (release == null) {
+            Timber.w("Update check: HTTP 2xx but body was null")
+            return UpdateCheckResult.Failed
+        }
 
         prefs.edit().putLong(KEY_LAST_CHECK, System.currentTimeMillis()).apply()
 
-        if (release.draft || release.prerelease) return null
+        if (release.draft || release.prerelease) return UpdateCheckResult.UpToDate
 
         val latest = release.tagName.removePrefix("v")
         val current = BuildConfig.VERSION_NAME
 
         return if (isNewer(latest, current)) {
-            Timber.i("Update available: $current → $latest")
-            UpdateInfo(latestVersion = latest, releaseUrl = release.htmlUrl)
+            Timber.i("Update available: %s → %s", current, latest)
+            UpdateCheckResult.Available(UpdateInfo(latestVersion = latest, releaseUrl = release.htmlUrl))
         } else {
-            null
+            UpdateCheckResult.UpToDate
         }
     }
 
@@ -50,20 +61,20 @@ class UpdateChecker @Inject constructor(
         return System.currentTimeMillis() - lastCheck >= CHECK_INTERVAL_MILLIS
     }
 
-    private fun isNewer(latest: String, current: String): Boolean {
-        val l = latest.split('.').mapNotNull { it.toIntOrNull() }
-        val c = current.split('.').mapNotNull { it.toIntOrNull() }
-        for (i in 0 until maxOf(l.size, c.size)) {
-            val a = l.getOrElse(i) { 0 }
-            val b = c.getOrElse(i) { 0 }
-            if (a != b) return a > b
-        }
-        return false
-    }
-
     companion object {
         private const val PREFS_NAME = "update_checker"
         private const val KEY_LAST_CHECK = "last_check_millis"
         private val CHECK_INTERVAL_MILLIS = TimeUnit.HOURS.toMillis(24)
+
+        internal fun isNewer(latest: String, current: String): Boolean {
+            val l = latest.split('.').mapNotNull { it.toIntOrNull() }
+            val c = current.split('.').mapNotNull { it.toIntOrNull() }
+            for (i in 0 until maxOf(l.size, c.size)) {
+                val a = l.getOrElse(i) { 0 }
+                val b = c.getOrElse(i) { 0 }
+                if (a != b) return a > b
+            }
+            return false
+        }
     }
 }

--- a/app/src/main/java/com/bikeshare/app/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/about/AboutScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material3.Button
@@ -27,6 +28,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -112,7 +114,9 @@ fun AboutScreen(
             UpdateStatusCard(
                 isChecking = uiState.isChecking,
                 updateInfo = uiState.updateInfo,
+                checkFailed = uiState.checkFailed,
                 onDownload = { url -> openUrl(context, url) },
+                onRetry = { viewModel.checkForUpdate() },
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -131,7 +135,9 @@ fun AboutScreen(
 private fun UpdateStatusCard(
     isChecking: Boolean,
     updateInfo: com.bikeshare.app.domain.update.UpdateInfo?,
+    checkFailed: Boolean,
     onDownload: (String) -> Unit,
+    onRetry: () -> Unit,
 ) {
     when {
         isChecking -> {
@@ -178,6 +184,37 @@ private fun UpdateStatusCard(
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         Text(stringResource(R.string.update_download))
+                    }
+                }
+            }
+        }
+        checkFailed -> {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                ),
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Default.ErrorOutline,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                        Spacer(modifier = Modifier.size(12.dp))
+                        Text(
+                            stringResource(R.string.about_check_failed),
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = onRetry,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(stringResource(R.string.about_retry_check))
                     }
                 }
             }

--- a/app/src/main/java/com/bikeshare/app/ui/about/AboutViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/about/AboutViewModel.kt
@@ -2,6 +2,7 @@ package com.bikeshare.app.ui.about
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.bikeshare.app.domain.update.UpdateCheckResult
 import com.bikeshare.app.domain.update.UpdateChecker
 import com.bikeshare.app.domain.update.UpdateInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,6 +15,7 @@ import javax.inject.Inject
 data class AboutUiState(
     val updateInfo: UpdateInfo? = null,
     val isChecking: Boolean = false,
+    val checkFailed: Boolean = false,
 )
 
 @HiltViewModel
@@ -30,10 +32,14 @@ class AboutViewModel @Inject constructor(
 
     fun checkForUpdate() {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isChecking = true)
+            _uiState.value = _uiState.value.copy(isChecking = true, checkFailed = false)
             // force = true: bypass the 24h throttle so user sees fresh result on demand
-            val info = updateChecker.checkForUpdate(force = true)
-            _uiState.value = AboutUiState(updateInfo = info, isChecking = false)
+            val result = updateChecker.checkForUpdate(force = true)
+            _uiState.value = AboutUiState(
+                updateInfo = (result as? UpdateCheckResult.Available)?.info,
+                isChecking = false,
+                checkFailed = result is UpdateCheckResult.Failed,
+            )
         }
     }
 }

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bikeshare.app.domain.repository.RentalRepository
+import com.bikeshare.app.domain.update.UpdateCheckResult
 import com.bikeshare.app.domain.update.UpdateChecker
 import com.bikeshare.app.domain.update.UpdateInfo
 import com.bikeshare.app.notification.FreeTimeNotificationScheduler
@@ -31,8 +32,10 @@ class AppViewModel @Inject constructor(
 
     fun checkForUpdate() {
         viewModelScope.launch {
-            val info = updateChecker.checkForUpdate() ?: return@launch
-            _updateInfo.value = info
+            val result = updateChecker.checkForUpdate()
+            if (result is UpdateCheckResult.Available) {
+                _updateInfo.value = result.info
+            }
         }
     }
 

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -136,6 +136,8 @@
     <string name="admin_coupon_copied">Kupón skopírovaný</string>
     <string name="about_checking_update">Kontroluje sa aktualizácia…</string>
     <string name="about_up_to_date">Máte najnovšiu verziu</string>
+    <string name="about_check_failed">Aktualizácie sa nepodarilo skontrolovať. Skontrolujte pripojenie a skúste znova.</string>
+    <string name="about_retry_check">Skúsiť znova</string>
 
     <!-- API messages from server (rent/return/revert flows). Names mirror server translation codes. -->
     <string name="api_bike_rent_success">Bicykel #%1$d: Otvoriť kódom %2$s. Okamžite zmeňte kód na %3$s (otvoriť, otočiť kovovú časť, nastaviť nový kód, otočiť kovovú časť späť).</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -136,6 +136,8 @@
     <string name="admin_coupon_copied">Купон скопійовано</string>
     <string name="about_checking_update">Перевірка оновлень…</string>
     <string name="about_up_to_date">У вас остання версія</string>
+    <string name="about_check_failed">Не вдалося перевірити оновлення. Перевірте з\'єднання та спробуйте ще раз.</string>
+    <string name="about_retry_check">Повторити</string>
 
     <!-- API messages from server (rent/return/revert flows). Names mirror server translation codes. -->
     <string name="api_bike_rent_success">Велосипед №%1$d: відкрити кодом %2$s. Негайно змініть код на %3$s (відкрити, повернути металеву частину, встановити новий код, повернути металеву частину назад).</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,8 @@
     <string name="admin_coupon_copied">Coupon copied to clipboard</string>
     <string name="about_checking_update">Checking for updates…</string>
     <string name="about_up_to_date">You have the latest version</string>
+    <string name="about_check_failed">Couldn\'t check for updates. Check your connection and try again.</string>
+    <string name="about_retry_check">Try again</string>
 
     <!-- API messages from server (rent/return/revert flows). Names mirror server translation codes. -->
     <string name="api_bike_rent_success">Bike #%1$d: Open with code %2$s. Change code immediately to %3$s (open, rotate metal part, set new code, rotate metal part back).</string>

--- a/app/src/test/java/com/bikeshare/app/domain/update/UpdateCheckerTest.kt
+++ b/app/src/test/java/com/bikeshare/app/domain/update/UpdateCheckerTest.kt
@@ -1,0 +1,47 @@
+package com.bikeshare.app.domain.update
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdateCheckerTest {
+
+    @Test
+    fun `1_0_6 sees 1_1_0 as newer`() {
+        // Reproduces the reported bug: a user on 1.0.6 must be notified of 1.1.0.
+        assertTrue(UpdateChecker.isNewer(latest = "1.1.0", current = "1.0.6"))
+    }
+
+    @Test
+    fun `same version is not newer`() {
+        assertFalse(UpdateChecker.isNewer(latest = "1.1.0", current = "1.1.0"))
+    }
+
+    @Test
+    fun `older version is not newer`() {
+        assertFalse(UpdateChecker.isNewer(latest = "1.0.5", current = "1.0.6"))
+    }
+
+    @Test
+    fun `patch bump is detected`() {
+        assertTrue(UpdateChecker.isNewer(latest = "1.0.7", current = "1.0.6"))
+    }
+
+    @Test
+    fun `major bump is detected`() {
+        assertTrue(UpdateChecker.isNewer(latest = "2.0.0", current = "1.99.99"))
+    }
+
+    @Test
+    fun `shorter latest matches with implicit zeros`() {
+        assertFalse(UpdateChecker.isNewer(latest = "1.0", current = "1.0.1"))
+        assertTrue(UpdateChecker.isNewer(latest = "1.1", current = "1.0.99"))
+    }
+
+    @Test
+    fun `non-numeric components are skipped`() {
+        // "1.0.6-rc1" splits to ["1","0","6-rc1"] — last toIntOrNull() returns null and is dropped.
+        // So "1.0.6-rc1" parses as [1,0] which compares less than [1,0,6].
+        assertFalse(UpdateChecker.isNewer(latest = "1.0.6-rc1", current = "1.0.6"))
+    }
+}


### PR DESCRIPTION
## Symptom

A user on **1.0.6 has been opening the app once a day** since v1.1.0 was released, and:
- launch snackbar never appears,
- About screen says "you have the latest version".

## Root cause

`UpdateChecker.checkForUpdate()` collapsed every failure mode (request thrown, HTTP non-2xx, null body) into a single `null` return, which the UI rendered as a green "up to date" checkmark. Most plausible failures for *that* user:

- **GitHub anonymous API rate limit** — 60 req/h per IP. A shared corporate NAT or mobile carrier exit easily exceeds it; everyone on that IP gets HTTP 403.
- **Corporate firewall / DNS** blocking `api.github.com`.

Either way, the user kept seeing "up to date" while in fact the check never succeeded. Throttle is not in play (24 h is far less than once-a-day).

## Fix

- `UpdateChecker` returns a sealed `UpdateCheckResult` (`Available` / `UpToDate` / `Failed` / `Disabled`). Each failure path is `Timber.w`-logged with the HTTP code where available, so Sentry will surface it next time.
- `AboutScreen` renders a third state — error card + retry button — instead of pretending all is well. `AboutViewModel` exposes `checkFailed` and re-runs on retry.
- `GitHubModule` adds `User-Agent`, `Accept: application/vnd.github+json`, `X-GitHub-Api-Version: 2022-11-28`. GitHub recommends a User-Agent and applies stricter rate limits without it, so this alone may already help users behind shared NATs.
- Snackbar consumer (`AppViewModel`) only reacts to `Available`, so out-of-About UX is unchanged.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — 36 tests pass, 7 new in `UpdateCheckerTest` (incl. the reproducer `1.0.6 → 1.1.0`)
- [x] `./gradlew :app:assembleDebug` builds clean
- [ ] Manual: airplane mode → open About → see "couldn't check, retry" instead of green checkmark; tap retry → spinner → same message
- [ ] Manual: with network → About → "update available" card or "you have the latest" depending on installed version
- [ ] After release: search Sentry/logs for `Update check returned HTTP 403` or `Update check threw` to identify which failure mode that specific user hits