### PR TITLE
fix(qr): auto-return on 1 rental + persistent return-code dialog

### DIFF
--- a/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
@@ -74,12 +74,6 @@ fun MapScreen(
         }
     }
 
-    LaunchedEffect(uiState.returnResult) {
-        uiState.returnResult?.let {
-            snackbarHostState.showSnackbar(it)
-            viewModel.clearReturnResult()
-        }
-    }
 
     val appContext = context.applicationContext
     LaunchedEffect(uiState.myBikes, uiState.limits) {
@@ -126,18 +120,26 @@ fun MapScreen(
         if (qrAction == null) return@LaunchedEffect
         when (qrAction) {
             "rent" -> qrBikeNumber?.let { viewModel.rentBike(it) }
-            "return" -> qrStandName?.let { stand ->
-                val myBikes = uiState.myBikes
-                if (myBikes.size == 1) {
-                    viewModel.returnBike(myBikes.first().bikeNum, stand)
-                } else {
-                    pendingReturnStand = stand
-                }
-            }
+            // Don't read myBikes here — when QR arrives via deep-link the API call
+            // for /me/bikes may not have returned yet, so myBikes can still be empty
+            // and the auto-return path would be missed. Defer to a separate effect
+            // that observes both pendingReturnStand and uiState.myBikes.
+            "return" -> qrStandName?.let { stand -> pendingReturnStand = stand }
         }
         qrSavedStateHandle?.remove<String>("qr_action")
         qrSavedStateHandle?.remove<Int>("qr_bike_number")
         qrSavedStateHandle?.remove<String>("qr_stand_name")
+    }
+
+    // Trigger auto-return as soon as we know there is exactly one rented bike. Re-runs
+    // when myBikes finally arrives, fixing the race where the QR-handling effect above
+    // would otherwise have shown the bike picker for size==0 momentarily.
+    LaunchedEffect(pendingReturnStand, uiState.myBikes) {
+        val stand = pendingReturnStand ?: return@LaunchedEffect
+        if (uiState.myBikes.size == 1) {
+            viewModel.returnBike(uiState.myBikes.first().bikeNum, stand)
+            pendingReturnStand = null
+        }
     }
 
     val mapViewRef = remember { mutableStateOf<org.osmdroid.views.MapView?>(null) }
@@ -299,6 +301,34 @@ fun MapScreen(
                         }
                     }
                 } else null,
+            )
+        }
+
+        // Return-success dialog. The lock code is the most important piece of info
+        // — using a persistent dialog instead of a 4 s snackbar so the user has time
+        // to read it and walk over to the bike.
+        uiState.returnCodeInfo?.let { returnInfo ->
+            AlertDialog(
+                onDismissRequest = { viewModel.clearReturnCodeInfo() },
+                title = { Text(stringResource(R.string.return_button)) },
+                text = {
+                    Column {
+                        uiState.returnCodeMessage?.takeIf { it.isNotBlank() }?.let { Text(it) }
+                        returnInfo.params?.currentCode?.let {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = "🔒 ${stringResource(R.string.lock_code, it)}",
+                                style = MaterialTheme.typography.titleLarge,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                },
+                confirmButton = {
+                    Button(onClick = { viewModel.clearReturnCodeInfo() }) {
+                        Text(stringResource(R.string.ok))
+                    }
+                },
             )
         }
 

--- a/app/src/main/java/com/bikeshare/app/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/MapViewModel.kt
@@ -32,7 +32,8 @@ data class MapUiState(
     val rentResult: String? = null,
     val rentCodeInfo: RentSystemResultDto? = null,
     val rentCodeMessage: String? = null,
-    val returnResult: String? = null,
+    val returnCodeInfo: RentSystemResultDto? = null,
+    val returnCodeMessage: String? = null,
 )
 
 @HiltViewModel
@@ -162,7 +163,8 @@ class MapViewModel @Inject constructor(
                     FreeTimeNotificationScheduler.cancelForBike(appContext, bikeNumber)
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
-                        returnResult = messageRenderer.renderFromDto(
+                        returnCodeInfo = result.data,
+                        returnCodeMessage = messageRenderer.renderFromDto(
                             result.data.code,
                             result.data.params,
                             fallback = result.data.message,
@@ -200,7 +202,7 @@ class MapViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(rentCodeInfo = null, rentCodeMessage = null)
     }
 
-    fun clearReturnResult() {
-        _uiState.value = _uiState.value.copy(returnResult = null)
+    fun clearReturnCodeInfo() {
+        _uiState.value = _uiState.value.copy(returnCodeInfo = null, returnCodeMessage = null)
     }
 }


### PR DESCRIPTION
## Symptoms (caught while testing #54 on a real Pixel 7)

1. Cold-starting the app via a stand deep-link with **exactly one rented bike** showed the bike-picker dialog with that single bike instead of auto-returning. Tapping the bike worked, but the extra step was unintended.
2. After a successful return, the **lock code only flashed in a 4 s snackbar** — not enough time for the user to walk over to the bike and key it in.

## Fix

### 1. Race condition in stand-QR handling

The QR-handling `LaunchedEffect` in `MapScreen` read `uiState.myBikes` directly. On cold-start via deep-link, the `/me/bikes` API call typically hasn't returned yet, so `myBikes` was still the empty default — `size == 1` was false, and the picker path was taken.

Decouple it: the QR effect just sets `pendingReturnStand`; a separate `LaunchedEffect(pendingReturnStand, uiState.myBikes)` triggers the auto-return the moment we observe exactly one rental. The picker dialog now only appears when `myBikes` is genuinely 0 or ≥2.

### 2. Persistent return dialog with the lock code

Mirror the rent-success pattern that already exists. New `returnCodeInfo` + `returnCodeMessage` fields on `MapUiState`; `MapViewModel.returnBike()` populates them on success. `MapScreen` renders an `AlertDialog` with the rendered message and a `🔒 Lock code: NNNN` line in the primary color. The legacy `returnResult` String + snackbar are removed.

## Test plan

- [x] Unit tests + lint pass on the new branch
- [x] **0 active rentals** + deep-link → "no rentals" dialog (unchanged)
- [x] **1 active rental** + deep-link → auto-return + persistent dialog showing the lock code (was: picker)
- [x] **2 active rentals** + deep-link → bike picker (unchanged)
- [x] All three verified on Pixel 7 (Android 16) against the local Docker backend with stand QRs `STAND2` / `STAND3`