### PR TITLE
ci(release): extract release fingerprint from keystore via keytool

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -130,23 +130,28 @@ jobs:
           mv app/build/outputs/apk/release/app-release.apk \
              app/build/outputs/apk/release/WhiteBikes-${{ steps.version.outputs.version_name }}.apk
 
-      - name: Extract APK signing fingerprint
+      - name: Extract release-key SHA-256 fingerprint
         id: fingerprint
+        env:
+          KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          APK=$(ls app/build/outputs/apk/release/*.apk | head -1)
-          # apksigner ships in Android SDK build-tools (pre-installed on ubuntu-latest
-          # at $ANDROID_SDK_ROOT). It supports v1/v2/v3 signing schemes — keytool only
-          # reads v1 (META-INF/*.RSA), which modern AGP no longer emits by default.
-          APKSIGNER=$(ls "$ANDROID_SDK_ROOT"/build-tools/*/apksigner | sort -V | tail -1)
-          RAW=$("$APKSIGNER" verify --print-certs "$APK" \
-            | awk -F': ' '/Signer #1 certificate SHA-256 digest:/ {print $2; exit}')
-          if [ -z "$RAW" ]; then
-            echo "::error::Could not extract SHA-256 fingerprint from $APK"
+          # Read straight from the keystore that just signed the APK. keytool ships
+          # with JDK 17 (already set up above) and prints colon-separated uppercase
+          # hex — the exact format assetlinks.json expects. Avoids the apksigner /
+          # ANDROID_SDK_ROOT path quirks across runner images.
+          FP=$(keytool -list -v \
+              -keystore "$KEYSTORE_FILE" \
+              -alias "$KEY_ALIAS" \
+              -storepass "$KEYSTORE_PASSWORD" \
+              -keypass "$KEY_PASSWORD" 2>/dev/null \
+            | awk -F': ' '/SHA256:/ {print $2; exit}')
+          if [ -z "$FP" ]; then
+            echo "::error::Could not extract SHA-256 fingerprint from keystore"
             exit 1
           fi
-          # apksigner emits lowercase hex without separators (e.g. ab12...). Convert to
-          # the colon-separated uppercase form expected by assetlinks.json (AB:12:...).
-          FP=$(echo "$RAW" | tr 'a-f' 'A-F' | sed 's/\(..\)/\1:/g; s/:$//')
           HOST=$(echo '${{ vars.API_BASE_URL }}' | sed -E 's|^https?://([^/]+).*|\1|')
           echo "sha256=$FP" >> $GITHUB_OUTPUT
           echo "assetlinks_url=https://$HOST/.well-known/assetlinks.json" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Why

v1.1.1 tag CI failed at the "Extract APK signing fingerprint" step:
> Could not extract SHA-256 fingerprint from app/build/outputs/apk/release/WhiteBikes-1.1.1.apk

The apksigner approach assumed `\$ANDROID_SDK_ROOT` was exported on the runner. On the `ubuntu-latest` image used by this workflow `setup-java` + `setup-gradle` don't export it, so the glob expanded to nothing, `APKSIGNER` was empty, and the awk pipeline produced no fingerprint.

## What

Read the SHA-256 straight from `release.keystore` via `keytool` (JDK 17 is already on PATH from `setup-java@v5`). `keytool -list -v` prints `SHA256:` lines in the colon-separated uppercase form `assetlinks.json` expects, so no extra normalization is needed. Keystore secrets stay in `env:` so they are not rendered into the job log.

## Test plan

- [x] YAML validates
- [ ] Re-tag v1.1.1 after merge → release job succeeds and the fingerprint appears in the GitHub Release notes