### PR TITLE
feat(map): switch from serviceTag to status enum

### DIFF
--- a/app/src/main/java/com/bikeshare/app/data/api/dto/StandDto.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/dto/StandDto.kt
@@ -12,7 +12,7 @@ data class StandMarkerDto(
     @Json(name = "latitude") val latitude: Double,
     @Json(name = "longitude") val longitude: Double,
     @Json(name = "bikeCount") val bikeCount: Int? = null,
-    @Json(name = "serviceTag") val serviceTag: Int? = null,
+    @Json(name = "status") val status: String? = null,
 )
 
 @JsonClass(generateAdapter = true)
@@ -21,7 +21,7 @@ data class StandDetailDto(
     @Json(name = "standName") val standName: String,
     @Json(name = "standDescription") val standDescription: String? = null,
     @Json(name = "standPhoto") val standPhoto: String? = null,
-    @Json(name = "serviceTag") val serviceTag: Int? = null,
+    @Json(name = "status") val status: String? = null,
     @Json(name = "placeName") val placeName: String? = null,
     @Json(name = "latitude") val latitude: Double? = null,
     @Json(name = "longitude") val longitude: Double? = null,

--- a/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
@@ -174,6 +174,7 @@ fun MapScreen(
         Box(modifier = Modifier.fillMaxSize().padding(padding)) {
             val bikesAvailableText = stringResource(R.string.bikes_available)
             val serviceStandLabel = stringResource(R.string.service_stand)
+            val hiddenStandLabel = stringResource(R.string.hidden_stand)
 
             AndroidView(
                 modifier = Modifier.fillMaxSize(),
@@ -197,18 +198,20 @@ fun MapScreen(
                     mapViewRef.value = mapView
                     mapView.overlays.removeAll { it is Marker }
                     uiState.stands.forEach { stand ->
-                        val isService = stand.serviceTag != null && stand.serviceTag != 0
-                        val (markerColor, label) = if (isService) {
-                            AndroidColor.parseColor("#FF9800") to "S" // orange for service
-                        } else {
-                            val bikes = stand.bikeCount ?: 0
-                            (if (bikes > 0) AndroidColor.parseColor("#4CAF50") else AndroidColor.parseColor("#F44336")) to bikes.toString()
+                        val (markerColor, label, statusLabel) = when (stand.status) {
+                            "technical" -> Triple(AndroidColor.parseColor("#FF9800"), "S", serviceStandLabel)
+                            "hidden" -> Triple(AndroidColor.parseColor("#9C27B0"), "H", hiddenStandLabel)
+                            else -> {
+                                val bikes = stand.bikeCount ?: 0
+                                val color = if (bikes > 0) AndroidColor.parseColor("#4CAF50") else AndroidColor.parseColor("#F44336")
+                                Triple(color, bikes.toString(), null)
+                            }
                         }
                         val markerIcon = createCircleMarker(mapView.context, markerColor, label)
                         val marker = Marker(mapView).apply {
                             position = GeoPoint(stand.latitude, stand.longitude)
-                            title = stand.standName + if (isService) " ($serviceStandLabel)" else ""
-                            snippet = if (isService) serviceStandLabel else "$label $bikesAvailableText"
+                            title = stand.standName + if (statusLabel != null) " ($statusLabel)" else ""
+                            snippet = statusLabel ?: "$label $bikesAvailableText"
                             icon = markerIcon
                             setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
                             setOnMarkerClickListener { _, _ ->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -48,6 +48,7 @@
     <string name="qr_unknown">Neznámy QR kód: %1$s</string>
     <string name="my_location">Moja poloha</string>
     <string name="service_stand">Servis</string>
+    <string name="hidden_stand">Test</string>
 
     <!-- Rentals -->
     <string name="no_rented_bikes">Nemáte žiadne požičané bicykle</string>
@@ -157,6 +158,7 @@
     <string name="api_bike_rent_error_insufficient_credit">Máte menej ako požadovaný kredit %1$s%2$s. Prosím, dobite si kredit.</string>
     <string name="api_bike_rent_error_zero_limit">Nemôžete si požičať žiadne bicykle. Kontaktujte administrátorov, aby zrušili zákaz.</string>
     <string name="api_bike_rent_error_service_stand">Požičiavanie zo servisných stojanov nie je povolené: Bicykel pravdepodobne čaká na opravu.</string>
+    <string name="api_bike_rent_error_inactive_stand">Požičiavanie z neaktívnych stojanov nie je povolené.</string>
     <string name="api_bike_rent_error_stack_top_bike">Bicykel #%1$d momentálne nie je možné si požičať, musíte si požičať bicykel #%2$d z tohto stojanu.</string>
     <plurals name="api_bike_rent_error_limit">
         <item quantity="one">Môžete si naraz požičať len %d bicykel.</item>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -48,6 +48,7 @@
     <string name="qr_unknown">Невідомий QR-код: %1$s</string>
     <string name="my_location">Моє місце</string>
     <string name="service_stand">Сервіс</string>
+    <string name="hidden_stand">Тест</string>
 
     <!-- Rentals -->
     <string name="no_rented_bikes">У вас немає орендованих велосипедів</string>
@@ -157,6 +158,7 @@
     <string name="api_bike_rent_error_insufficient_credit">Ваш кредит менший за необхідний %1$s%2$s. Будь ласка, поповніть кредит.</string>
     <string name="api_bike_rent_error_zero_limit">Ви не можете орендувати велосипеди. Зверніться до адміністраторів, щоб зняти заборону.</string>
     <string name="api_bike_rent_error_service_stand">Оренда зі сервісних стоянок не дозволена: велосипед, ймовірно, чекає на ремонт.</string>
+    <string name="api_bike_rent_error_inactive_stand">Оренда з неактивних стоянок не дозволена.</string>
     <string name="api_bike_rent_error_stack_top_bike">Велосипед №%1$d зараз неможливо орендувати, ви маєте орендувати велосипед №%2$d з цієї стоянки.</string>
     <plurals name="api_bike_rent_error_limit">
         <item quantity="one">Ви можете орендувати одночасно лише %d велосипед.</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="qr_unknown">Unknown QR code: %1$s</string>
     <string name="my_location">My location</string>
     <string name="service_stand">Service</string>
+    <string name="hidden_stand">Testing</string>
 
     <!-- Rentals -->
     <string name="no_rented_bikes">You have no rented bikes</string>
@@ -157,6 +158,7 @@
     <string name="api_bike_rent_error_insufficient_credit">You are below required credit %1$s%2$s. Please, recharge your credit.</string>
     <string name="api_bike_rent_error_zero_limit">You can not rent any bikes. Contact the admins to lift the ban.</string>
     <string name="api_bike_rent_error_service_stand">Renting from service stands is not allowed: The bike probably waits for a repair.</string>
+    <string name="api_bike_rent_error_inactive_stand">Renting from inactive stands is not allowed.</string>
     <string name="api_bike_rent_error_stack_top_bike">Bike #%1$d is not rentable now, you have to rent bike #%2$d from this stand.</string>
     <plurals name="api_bike_rent_error_limit">
         <item quantity="one">You can only rent %d bike at once.</item>


### PR DESCRIPTION
## Summary

Backend introduced a four-value `status` enum on stands (active, technical, hidden, inactive), replacing the binary `serviceTag` flag. See [cyklokoalicia/OpenSourceBikeShare#317](https://github.com/cyklokoalicia/OpenSourceBikeShare/pull/317).

This PR adopts the new contract on the Android side. **Should be released as v1.1.2** to match the server's compat-transform threshold (`AddServiceTagFromStatusTransform.getSinceVersion() == '1.1.2'`).

## Changes

**DTO**
- `StandMarkerDto`, `StandDetailDto`: `serviceTag: Int?` → `status: String?`.

**Map UI** (`MapScreen.kt`)
- Marker color/label/snippet driven by `status`:
  - `technical` → orange "S" + "Service" snippet *(existing behavior)*
  - `hidden` → purple "H" + "Testing" snippet *(new — only reaches the client when logged in as admin)*
  - default (active or unknown) → green/red by bike count *(existing behavior)*
- `inactive` doesn't reach the client (server filters it out for everyone).

**Strings**
- `hidden_stand` ("Testing" / "Test" / "Тест") in en/sk/uk.
- `api_bike_rent_error_inactive_stand` in en/sk/uk to match the new server-side translation key.

## Backwards compatibility

- Older installed app versions (<1.1.2) keep working unchanged: the server detects them by User-Agent (`okhttp/*` or `<App>-Android/<x.y.z (<1.1.2)`) and the existing `ApiResponseTransformInterface` mechanism injects a derived `serviceTag` field into the response. No coordinated rollout needed.
- Once this is tagged `v1.1.2`, the server stops shipping `serviceTag` to this client (and only this client), and the new code reads `status` directly.

## Test plan

- [x] Visual review of touch points (`StandDto.kt`, `MapScreen.kt`).
- [ ] CI: `./gradlew assembleDebug`, `./gradlew lintDebug`, `./gradlew testDebugUnitTest` all green.
- [ ] Manual on debug build:
  - Map as regular user → only active+technical stands visible; technical shows orange "S" with "Service" snippet.
  - Map as admin (`privileges >= 1`) → hidden stands appear with purple "H" + "Testing" snippet; selecting one shows correct title.
  - Force `inactive` status server-side as a defensive check — should not appear at all.
  - Try renting from a technical/hidden stand as user → server returns `bike.rent.error.service_stand`. As admin → success.
  - Try renting from an `inactive` stand server-side → `bike.rent.error.inactive_stand` (new key, surfaces via the existing rent error path).

## Notes

- Version bump happens via release tag (`v1.1.2`), not in `app/build.gradle.kts`.
- Local build wasn't run because the dev box has no Android SDK; relying on GitHub Actions for `assembleDebug`/`lintDebug`/`testDebugUnitTest`.