### PR TITLE
feat(admin): status filter pills and color coding for stands & bikes

### DIFF
--- a/app/src/main/java/com/bikeshare/app/ui/admin/StatusColors.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/StatusColors.kt
@@ -1,6 +1,13 @@
 package com.bikeshare.app.ui.admin
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.DirectionsBike
 import androidx.compose.material.icons.filled.Block
@@ -9,8 +16,17 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.bikeshare.app.R
 
 /**
@@ -54,8 +70,40 @@ val BikeStatusOptions: List<StatusOption> = listOf(
     StatusOption("ok", R.string.bike_status_ok, Icons.AutoMirrored.Filled.DirectionsBike, null),
 )
 
-fun standStatusOption(status: String?): StatusOption? =
-    status?.let { key -> StandStatusOptions.firstOrNull { it.key == key } }
+private val StandStatusByKey: Map<String, StatusOption> = StandStatusOptions.associateBy { it.key }
+private val BikeStatusByKey: Map<String, StatusOption> = BikeStatusOptions.associateBy { it.key }
 
-fun bikeStatusOption(status: String?): StatusOption? =
-    status?.let { key -> BikeStatusOptions.firstOrNull { it.key == key } }
+fun standStatusOption(status: String?): StatusOption? = status?.let(StandStatusByKey::get)
+
+fun bikeStatusOption(status: String?): StatusOption? = status?.let(BikeStatusByKey::get)
+
+/** Returns a copy of the set with `element` toggled (added if absent, removed if present). */
+fun <T> Set<T>.toggleElement(element: T): Set<T> =
+    toMutableSet().apply { if (!add(element)) remove(element) }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StatusFilterRow(
+    options: List<StatusOption>,
+    selected: Set<String>,
+    onToggle: (String) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        options.forEach { option ->
+            FilterChip(
+                selected = option.key in selected,
+                onClick = { onToggle(option.key) },
+                label = { Text(stringResource(option.labelRes)) },
+                leadingIcon = option.icon?.let {
+                    { Icon(it, contentDescription = null, modifier = Modifier.size(FilterChipDefaults.IconSize)) }
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/bikeshare/app/ui/admin/StatusColors.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/StatusColors.kt
@@ -1,0 +1,35 @@
+package com.bikeshare.app.ui.admin
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Status palette mirroring the web admin UI (Bootstrap utility colors).
+ * Kept light enough for white-on-color text to remain legible on the card
+ * header strip (or background tint on bike cards).
+ */
+data class StatusPalette(val container: Color, val onContainer: Color)
+
+private val Success = StatusPalette(container = Color(0xFF4CAF50), onContainer = Color.White)
+private val Warning = StatusPalette(container = Color(0xFFFF9800), onContainer = Color.Black)
+private val Info = StatusPalette(container = Color(0xFF17A2B8), onContainer = Color.White)
+private val Secondary = StatusPalette(container = Color(0xFF6C757D), onContainer = Color.White)
+private val Primary = StatusPalette(container = Color(0xFF2196F3), onContainer = Color.White)
+
+private val StandStatusPalettes: Map<String, StatusPalette> = mapOf(
+    "active" to Success,
+    "technical" to Warning,
+    "hidden" to Info,
+    "inactive" to Secondary,
+    "virtual" to Primary,
+)
+
+private val BikeStatusPalettes: Map<String, StatusPalette> = mapOf(
+    "rented" to Success,
+    "problematic" to Warning,
+    "ok" to Secondary,
+)
+
+fun standStatusPalette(status: String?): StatusPalette? =
+    status?.let { StandStatusPalettes[it] }
+
+fun bikeStatusPalette(status: String): StatusPalette? = BikeStatusPalettes[status]

--- a/app/src/main/java/com/bikeshare/app/ui/admin/StatusColors.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/StatusColors.kt
@@ -1,6 +1,17 @@
 package com.bikeshare.app.ui.admin
 
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.DirectionsBike
+import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.bikeshare.app.R
 
 /**
  * Status palette mirroring the web admin UI (Bootstrap utility colors).
@@ -15,21 +26,36 @@ private val Info = StatusPalette(container = Color(0xFF17A2B8), onContainer = Co
 private val Secondary = StatusPalette(container = Color(0xFF6C757D), onContainer = Color.White)
 private val Primary = StatusPalette(container = Color(0xFF2196F3), onContainer = Color.White)
 
-private val StandStatusPalettes: Map<String, StatusPalette> = mapOf(
-    "active" to Success,
-    "technical" to Warning,
-    "hidden" to Info,
-    "inactive" to Secondary,
-    "virtual" to Primary,
+/**
+ * Single source of truth for an admin status — used by filter chip rows AND
+ * card visuals. Adding a new status means appending one entry here.
+ *
+ * `palette = null` means "no special tint, fall back to MaterialTheme surface"
+ * — used for OK bikes so their cards look neutral (mirroring web's `bg-light`).
+ */
+data class StatusOption(
+    val key: String,
+    @StringRes val labelRes: Int,
+    val icon: ImageVector?,
+    val palette: StatusPalette?,
 )
 
-private val BikeStatusPalettes: Map<String, StatusPalette> = mapOf(
-    "rented" to Success,
-    "problematic" to Warning,
-    "ok" to Secondary,
+val StandStatusOptions: List<StatusOption> = listOf(
+    StatusOption("active", R.string.stand_status_active, null, Success),
+    StatusOption("technical", R.string.stand_status_technical, Icons.Default.Build, Warning),
+    StatusOption("hidden", R.string.stand_status_hidden, Icons.Default.VisibilityOff, Info),
+    StatusOption("inactive", R.string.stand_status_inactive, Icons.Default.Block, Secondary),
+    StatusOption("virtual", R.string.stand_status_virtual, Icons.Default.Public, Primary),
 )
 
-fun standStatusPalette(status: String?): StatusPalette? =
-    status?.let { StandStatusPalettes[it] }
+val BikeStatusOptions: List<StatusOption> = listOf(
+    StatusOption("problematic", R.string.bike_status_problematic, Icons.Default.Warning, Warning),
+    StatusOption("rented", R.string.bike_status_rented, Icons.Default.Person, Success),
+    StatusOption("ok", R.string.bike_status_ok, Icons.AutoMirrored.Filled.DirectionsBike, null),
+)
 
-fun bikeStatusPalette(status: String): StatusPalette? = BikeStatusPalettes[status]
+fun standStatusOption(status: String?): StatusOption? =
+    status?.let { key -> StandStatusOptions.firstOrNull { it.key == key } }
+
+fun bikeStatusOption(status: String?): StatusOption? =
+    status?.let { key -> BikeStatusOptions.firstOrNull { it.key == key } }

--- a/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesScreen.kt
@@ -10,33 +10,19 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.DirectionsBike
 import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bikeshare.app.R
 import com.bikeshare.app.data.api.dto.BikeDetailDto
-import com.bikeshare.app.ui.admin.bikeStatusPalette
-
-private data class BikeStatusOption(
-    val value: String,
-    val labelRes: Int,
-    val icon: ImageVector,
-)
-
-private val BikeStatusOptions = listOf(
-    BikeStatusOption("problematic", R.string.bike_status_problematic, Icons.Default.Warning),
-    BikeStatusOption("rented", R.string.bike_status_rented, Icons.Default.Person),
-    BikeStatusOption("ok", R.string.bike_status_ok, Icons.AutoMirrored.Filled.DirectionsBike),
-)
+import com.bikeshare.app.ui.admin.BikeStatusOptions
+import com.bikeshare.app.ui.admin.bikeStatusOption
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -132,11 +118,11 @@ private fun BikeStatusFilterRow(
     ) {
         BikeStatusOptions.forEach { option ->
             FilterChip(
-                selected = option.value in selected,
-                onClick = { onToggle(option.value) },
+                selected = option.key in selected,
+                onClick = { onToggle(option.key) },
                 label = { Text(stringResource(option.labelRes)) },
-                leadingIcon = {
-                    Icon(option.icon, contentDescription = null, modifier = Modifier.size(FilterChipDefaults.IconSize))
+                leadingIcon = option.icon?.let {
+                    { Icon(it, contentDescription = null, modifier = Modifier.size(FilterChipDefaults.IconSize)) }
                 },
             )
         }
@@ -145,9 +131,9 @@ private fun BikeStatusFilterRow(
 
 @Composable
 private fun BikeCard(bike: BikeDetailDto, onClick: () -> Unit) {
-    val palette = bikeStatusPalette(bike.derivedStatus())
-    val containerColor = palette?.container ?: MaterialTheme.colorScheme.surface
-    val onColor = palette?.onContainer ?: MaterialTheme.colorScheme.onSurface
+    val option = bikeStatusOption(bike.derivedStatus())
+    val containerColor = option?.palette?.container ?: MaterialTheme.colorScheme.surface
+    val onColor = option?.palette?.onContainer ?: MaterialTheme.colorScheme.onSurface
 
     Card(
         modifier = Modifier

--- a/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesScreen.kt
@@ -1,23 +1,42 @@
 package com.bikeshare.app.ui.admin.bikes
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.DirectionsBike
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bikeshare.app.R
+import com.bikeshare.app.data.api.dto.BikeDetailDto
+import com.bikeshare.app.ui.admin.bikeStatusPalette
+
+private data class BikeStatusOption(
+    val value: String,
+    val labelRes: Int,
+    val icon: ImageVector,
+)
+
+private val BikeStatusOptions = listOf(
+    BikeStatusOption("problematic", R.string.bike_status_problematic, Icons.Default.Warning),
+    BikeStatusOption("rented", R.string.bike_status_rented, Icons.Default.Person),
+    BikeStatusOption("ok", R.string.bike_status_ok, Icons.AutoMirrored.Filled.DirectionsBike),
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -29,13 +48,21 @@ fun AdminBikesScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var searchQuery by remember { mutableStateOf("") }
 
-    val filteredBikes = remember(uiState.bikes, searchQuery) {
-        if (searchQuery.isBlank()) uiState.bikes
-        else uiState.bikes.filter { bike ->
-            bike.bikeNum.toString().contains(searchQuery, ignoreCase = true) ||
-                bike.standName?.contains(searchQuery, ignoreCase = true) == true ||
-                bike.userName?.contains(searchQuery, ignoreCase = true) == true ||
-                bike.notes?.contains(searchQuery, ignoreCase = true) == true
+    val filteredBikes = remember(uiState.bikes, uiState.selectedStatuses, searchQuery) {
+        val byStatus = if (uiState.selectedStatuses.isEmpty()) {
+            uiState.bikes
+        } else {
+            uiState.bikes.filter { it.derivedStatus() in uiState.selectedStatuses }
+        }
+        if (searchQuery.isBlank()) {
+            byStatus
+        } else {
+            byStatus.filter { bike ->
+                bike.bikeNum.toString().contains(searchQuery, ignoreCase = true) ||
+                    bike.standName?.contains(searchQuery, ignoreCase = true) == true ||
+                    bike.userName?.contains(searchQuery, ignoreCase = true) == true ||
+                    bike.notes?.contains(searchQuery, ignoreCase = true) == true
+            }
         }
     }
 
@@ -52,6 +79,10 @@ fun AdminBikesScreen(
         },
     ) { padding ->
         Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            BikeStatusFilterRow(
+                selected = uiState.selectedStatuses,
+                onToggle = viewModel::toggleStatusFilter,
+            )
             OutlinedTextField(
                 value = searchQuery,
                 onValueChange = { searchQuery = it },
@@ -77,32 +108,70 @@ fun AdminBikesScreen(
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         items(filteredBikes) { bike ->
-                            Card(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .clickable { onBikeClick(bike.bikeNum) },
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(16.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    Icon(Icons.AutoMirrored.Filled.DirectionsBike, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-                                    Spacer(modifier = Modifier.width(12.dp))
-                                    Column {
-                                        Text("#${bike.bikeNum}", style = MaterialTheme.typography.titleMedium)
-                                        bike.standName?.let {
-                                            Text("Stand: $it", style = MaterialTheme.typography.bodySmall)
-                                        }
-                                        bike.userName?.let {
-                                            Text("User: $it", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
-                                        }
-                                        bike.notes?.let {
-                                            if (it.isNotBlank()) Text("⚠ $it", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
-                                        }
-                                    }
-                                }
-                            }
+                            BikeCard(bike = bike, onClick = { onBikeClick(bike.bikeNum) })
                         }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BikeStatusFilterRow(
+    selected: Set<String>,
+    onToggle: (String) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        BikeStatusOptions.forEach { option ->
+            FilterChip(
+                selected = option.value in selected,
+                onClick = { onToggle(option.value) },
+                label = { Text(stringResource(option.labelRes)) },
+                leadingIcon = {
+                    Icon(option.icon, contentDescription = null, modifier = Modifier.size(FilterChipDefaults.IconSize))
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BikeCard(bike: BikeDetailDto, onClick: () -> Unit) {
+    val palette = bikeStatusPalette(bike.derivedStatus())
+    val containerColor = palette?.container ?: MaterialTheme.colorScheme.surface
+    val onColor = palette?.onContainer ?: MaterialTheme.colorScheme.onSurface
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = containerColor, contentColor = onColor),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.AutoMirrored.Filled.DirectionsBike, contentDescription = null, tint = onColor)
+            Spacer(modifier = Modifier.width(12.dp))
+            Column {
+                Text("#${bike.bikeNum}", style = MaterialTheme.typography.titleMedium, color = onColor)
+                bike.standName?.let {
+                    Text("Stand: $it", style = MaterialTheme.typography.bodySmall, color = onColor)
+                }
+                bike.userName?.let {
+                    Text("User: $it", style = MaterialTheme.typography.bodySmall, color = onColor)
+                }
+                bike.notes?.let {
+                    if (it.isNotBlank()) {
+                        Text("⚠ $it", style = MaterialTheme.typography.bodySmall, color = onColor)
                     }
                 }
             }

--- a/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesScreen.kt
@@ -1,11 +1,9 @@
 package com.bikeshare.app.ui.admin.bikes
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.DirectionsBike
@@ -22,6 +20,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bikeshare.app.R
 import com.bikeshare.app.data.api.dto.BikeDetailDto
 import com.bikeshare.app.ui.admin.BikeStatusOptions
+import com.bikeshare.app.ui.admin.StatusFilterRow
 import com.bikeshare.app.ui.admin.bikeStatusOption
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -65,7 +64,8 @@ fun AdminBikesScreen(
         },
     ) { padding ->
         Column(modifier = Modifier.fillMaxSize().padding(padding)) {
-            BikeStatusFilterRow(
+            StatusFilterRow(
+                options = BikeStatusOptions,
                 selected = uiState.selectedStatuses,
                 onToggle = viewModel::toggleStatusFilter,
             )
@@ -99,32 +99,6 @@ fun AdminBikesScreen(
                     }
                 }
             }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun BikeStatusFilterRow(
-    selected: Set<String>,
-    onToggle: (String) -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .horizontalScroll(rememberScrollState())
-            .padding(horizontal = 12.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        BikeStatusOptions.forEach { option ->
-            FilterChip(
-                selected = option.key in selected,
-                onClick = { onToggle(option.key) },
-                label = { Text(stringResource(option.labelRes)) },
-                leadingIcon = option.icon?.let {
-                    { Icon(it, contentDescription = null, modifier = Modifier.size(FilterChipDefaults.IconSize)) }
-                },
-            )
         }
     }
 }

--- a/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesViewModel.kt
@@ -4,12 +4,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bikeshare.app.data.api.ApiService
 import com.bikeshare.app.data.api.dto.BikeDetailDto
+import com.bikeshare.app.ui.admin.toggleElement
 import com.bikeshare.app.util.NetworkResult
 import com.bikeshare.app.util.safeApiCall
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -40,11 +42,7 @@ class AdminBikesViewModel @Inject constructor(
     }
 
     fun toggleStatusFilter(status: String) {
-        _uiState.value = _uiState.value.copy(
-            selectedStatuses = _uiState.value.selectedStatuses
-                .toMutableSet()
-                .apply { if (!add(status)) remove(status) }
-        )
+        _uiState.update { it.copy(selectedStatuses = it.selectedStatuses.toggleElement(status)) }
     }
 
     fun loadBikes() {

--- a/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/bikes/AdminBikesViewModel.kt
@@ -15,9 +15,16 @@ import javax.inject.Inject
 
 data class AdminBikesUiState(
     val bikes: List<BikeDetailDto> = emptyList(),
+    val selectedStatuses: Set<String> = emptySet(),
     val isLoading: Boolean = false,
     val error: String? = null,
 )
+
+fun BikeDetailDto.derivedStatus(): String = when {
+    userName != null -> "rented"
+    !notes.isNullOrBlank() -> "problematic"
+    else -> "ok"
+}
 
 @HiltViewModel
 class AdminBikesViewModel @Inject constructor(
@@ -32,15 +39,27 @@ class AdminBikesViewModel @Inject constructor(
         loadBikes()
     }
 
+    fun toggleStatusFilter(status: String) {
+        _uiState.value = _uiState.value.copy(
+            selectedStatuses = _uiState.value.selectedStatuses
+                .toMutableSet()
+                .apply { if (!add(status)) remove(status) }
+        )
+    }
+
     fun loadBikes() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true)
             when (val result = safeApiCall(moshi) { api.getAdminBikes() }) {
                 is NetworkResult.Success -> {
-                    _uiState.value = AdminBikesUiState(bikes = result.data)
+                    _uiState.value = _uiState.value.copy(
+                        bikes = result.data,
+                        isLoading = false,
+                        error = null,
+                    )
                 }
                 is NetworkResult.Error -> {
-                    _uiState.value = AdminBikesUiState(error = result.message)
+                    _uiState.value = _uiState.value.copy(error = result.message, isLoading = false)
                 }
                 is NetworkResult.Loading -> {}
             }

--- a/app/src/main/java/com/bikeshare/app/ui/admin/stands/AdminStandsScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/stands/AdminStandsScreen.kt
@@ -8,37 +8,19 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Block
-import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Place
-import androidx.compose.material.icons.filled.Public
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bikeshare.app.R
 import com.bikeshare.app.data.api.dto.StandDetailDto
-import com.bikeshare.app.ui.admin.standStatusPalette
-
-private data class StandStatusOption(
-    val value: String,
-    val labelRes: Int,
-    val icon: ImageVector?,
-)
-
-private val StandStatusOptions = listOf(
-    StandStatusOption("active", R.string.stand_status_active, null),
-    StandStatusOption("technical", R.string.stand_status_technical, Icons.Default.Build),
-    StandStatusOption("hidden", R.string.stand_status_hidden, Icons.Default.VisibilityOff),
-    StandStatusOption("inactive", R.string.stand_status_inactive, Icons.Default.Block),
-    StandStatusOption("virtual", R.string.stand_status_virtual, Icons.Default.Public),
-)
+import com.bikeshare.app.ui.admin.StandStatusOptions
+import com.bikeshare.app.ui.admin.standStatusOption
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -98,8 +80,8 @@ private fun StandStatusFilterRow(
     ) {
         StandStatusOptions.forEach { option ->
             FilterChip(
-                selected = option.value in selected,
-                onClick = { onToggle(option.value) },
+                selected = option.key in selected,
+                onClick = { onToggle(option.key) },
                 label = { Text(stringResource(option.labelRes)) },
                 leadingIcon = option.icon?.let {
                     { Icon(it, contentDescription = null, modifier = Modifier.size(FilterChipDefaults.IconSize)) }
@@ -111,17 +93,17 @@ private fun StandStatusFilterRow(
 
 @Composable
 private fun StandCard(stand: StandDetailDto) {
-    val palette = standStatusPalette(stand.status)
+    val option = standStatusOption(stand.status)
     Card(modifier = Modifier.fillMaxWidth()) {
         Column {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(palette?.container ?: MaterialTheme.colorScheme.surfaceVariant)
+                    .background(option?.palette?.container ?: MaterialTheme.colorScheme.surfaceVariant)
                     .padding(horizontal = 16.dp, vertical = 10.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                val onColor = palette?.onContainer ?: MaterialTheme.colorScheme.onSurfaceVariant
+                val onColor = option?.palette?.onContainer ?: MaterialTheme.colorScheme.onSurfaceVariant
                 Icon(Icons.Default.Place, contentDescription = null, tint = onColor)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
@@ -130,9 +112,9 @@ private fun StandCard(stand: StandDetailDto) {
                     color = onColor,
                     modifier = Modifier.weight(1f),
                 )
-                stand.status?.let {
+                option?.let {
                     Text(
-                        text = it.replaceFirstChar(Char::uppercase),
+                        text = stringResource(it.labelRes),
                         style = MaterialTheme.typography.labelSmall,
                         color = onColor,
                     )

--- a/app/src/main/java/com/bikeshare/app/ui/admin/stands/AdminStandsScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/stands/AdminStandsScreen.kt
@@ -1,21 +1,44 @@
 package com.bikeshare.app.ui.admin.stands
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bikeshare.app.R
+import com.bikeshare.app.data.api.dto.StandDetailDto
+import com.bikeshare.app.ui.admin.standStatusPalette
+
+private data class StandStatusOption(
+    val value: String,
+    val labelRes: Int,
+    val icon: ImageVector?,
+)
+
+private val StandStatusOptions = listOf(
+    StandStatusOption("active", R.string.stand_status_active, null),
+    StandStatusOption("technical", R.string.stand_status_technical, Icons.Default.Build),
+    StandStatusOption("hidden", R.string.stand_status_hidden, Icons.Default.VisibilityOff),
+    StandStatusOption("inactive", R.string.stand_status_inactive, Icons.Default.Block),
+    StandStatusOption("virtual", R.string.stand_status_virtual, Icons.Default.Public),
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -37,36 +60,90 @@ fun AdminStandsScreen(
             )
         },
     ) { padding ->
-        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
-            if (uiState.isLoading && uiState.stands.isEmpty()) {
-                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-            } else {
-                LazyColumn(
-                    contentPadding = PaddingValues(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    items(uiState.stands) { stand ->
-                        Card(modifier = Modifier.fillMaxWidth()) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(16.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Icon(Icons.Default.Place, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Column {
-                                    Text(stand.standName, style = MaterialTheme.typography.titleMedium)
-                                    stand.standDescription?.let {
-                                        Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                                    }
-                                    stand.placeName?.let {
-                                        Text(it, style = MaterialTheme.typography.bodySmall)
-                                    }
-                                }
-                            }
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            StandStatusFilterRow(
+                selected = uiState.selectedStatuses,
+                onToggle = viewModel::toggleStatusFilter,
+            )
+            Box(modifier = Modifier.fillMaxSize()) {
+                if (uiState.isLoading && uiState.stands.isEmpty()) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                } else {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(uiState.visibleStands) { stand ->
+                            StandCard(stand = stand)
                         }
                     }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun StandStatusFilterRow(
+    selected: Set<String>,
+    onToggle: (String) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        StandStatusOptions.forEach { option ->
+            FilterChip(
+                selected = option.value in selected,
+                onClick = { onToggle(option.value) },
+                label = { Text(stringResource(option.labelRes)) },
+                leadingIcon = option.icon?.let {
+                    { Icon(it, contentDescription = null, modifier = Modifier.size(FilterChipDefaults.IconSize)) }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun StandCard(stand: StandDetailDto) {
+    val palette = standStatusPalette(stand.status)
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(palette?.container ?: MaterialTheme.colorScheme.surfaceVariant)
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                val onColor = palette?.onContainer ?: MaterialTheme.colorScheme.onSurfaceVariant
+                Icon(Icons.Default.Place, contentDescription = null, tint = onColor)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stand.standName,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = onColor,
+                    modifier = Modifier.weight(1f),
+                )
+                stand.status?.let {
+                    Text(
+                        text = it.replaceFirstChar(Char::uppercase),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = onColor,
+                    )
+                }
+            }
+            Column(modifier = Modifier.padding(16.dp)) {
+                stand.standDescription?.let {
+                    Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                stand.placeName?.let {
+                    Text(it, style = MaterialTheme.typography.bodySmall)
                 }
             }
         }

--- a/app/src/main/java/com/bikeshare/app/ui/admin/stands/AdminStandsScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/stands/AdminStandsScreen.kt
@@ -1,11 +1,9 @@
 package com.bikeshare.app.ui.admin.stands
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Place
@@ -20,6 +18,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bikeshare.app.R
 import com.bikeshare.app.data.api.dto.StandDetailDto
 import com.bikeshare.app.ui.admin.StandStatusOptions
+import com.bikeshare.app.ui.admin.StatusFilterRow
 import com.bikeshare.app.ui.admin.standStatusOption
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -29,6 +28,14 @@ fun AdminStandsScreen(
     viewModel: AdminStandsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val visibleStands = remember(uiState.stands, uiState.selectedStatuses) {
+        if (uiState.selectedStatuses.isEmpty()) {
+            uiState.stands
+        } else {
+            uiState.stands.filter { (it.status ?: "active") in uiState.selectedStatuses }
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -43,7 +50,8 @@ fun AdminStandsScreen(
         },
     ) { padding ->
         Column(modifier = Modifier.fillMaxSize().padding(padding)) {
-            StandStatusFilterRow(
+            StatusFilterRow(
+                options = StandStatusOptions,
                 selected = uiState.selectedStatuses,
                 onToggle = viewModel::toggleStatusFilter,
             )
@@ -55,38 +63,12 @@ fun AdminStandsScreen(
                         contentPadding = PaddingValues(16.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        items(uiState.visibleStands) { stand ->
+                        items(visibleStands) { stand ->
                             StandCard(stand = stand)
                         }
                     }
                 }
             }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun StandStatusFilterRow(
-    selected: Set<String>,
-    onToggle: (String) -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .horizontalScroll(rememberScrollState())
-            .padding(horizontal = 12.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        StandStatusOptions.forEach { option ->
-            FilterChip(
-                selected = option.key in selected,
-                onClick = { onToggle(option.key) },
-                label = { Text(stringResource(option.labelRes)) },
-                leadingIcon = option.icon?.let {
-                    { Icon(it, contentDescription = null, modifier = Modifier.size(FilterChipDefaults.IconSize)) }
-                },
-            )
         }
     }
 }

--- a/app/src/main/java/com/bikeshare/app/ui/admin/stands/AdminStandsViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/stands/AdminStandsViewModel.kt
@@ -4,12 +4,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bikeshare.app.data.api.ApiService
 import com.bikeshare.app.data.api.dto.StandDetailDto
+import com.bikeshare.app.ui.admin.toggleElement
 import com.bikeshare.app.util.NetworkResult
 import com.bikeshare.app.util.safeApiCall
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,14 +21,7 @@ data class AdminStandsUiState(
     val isLoading: Boolean = false,
     val error: String? = null,
     val message: String? = null,
-) {
-    val visibleStands: List<StandDetailDto>
-        get() = if (selectedStatuses.isEmpty()) {
-            stands
-        } else {
-            stands.filter { (it.status ?: "active") in selectedStatuses }
-        }
-}
+)
 
 @HiltViewModel
 class AdminStandsViewModel @Inject constructor(
@@ -42,11 +37,7 @@ class AdminStandsViewModel @Inject constructor(
     }
 
     fun toggleStatusFilter(status: String) {
-        _uiState.value = _uiState.value.copy(
-            selectedStatuses = _uiState.value.selectedStatuses
-                .toMutableSet()
-                .apply { if (!add(status)) remove(status) }
-        )
+        _uiState.update { it.copy(selectedStatuses = it.selectedStatuses.toggleElement(status)) }
     }
 
     fun loadStands() {

--- a/app/src/main/java/com/bikeshare/app/ui/admin/stands/AdminStandsViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/admin/stands/AdminStandsViewModel.kt
@@ -15,10 +15,18 @@ import javax.inject.Inject
 
 data class AdminStandsUiState(
     val stands: List<StandDetailDto> = emptyList(),
+    val selectedStatuses: Set<String> = emptySet(),
     val isLoading: Boolean = false,
     val error: String? = null,
     val message: String? = null,
-)
+) {
+    val visibleStands: List<StandDetailDto>
+        get() = if (selectedStatuses.isEmpty()) {
+            stands
+        } else {
+            stands.filter { (it.status ?: "active") in selectedStatuses }
+        }
+}
 
 @HiltViewModel
 class AdminStandsViewModel @Inject constructor(
@@ -31,6 +39,14 @@ class AdminStandsViewModel @Inject constructor(
 
     init {
         loadStands()
+    }
+
+    fun toggleStatusFilter(status: String) {
+        _uiState.value = _uiState.value.copy(
+            selectedStatuses = _uiState.value.selectedStatuses
+                .toMutableSet()
+                .apply { if (!add(status)) remove(status) }
+        )
     }
 
     fun loadStands() {

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -128,6 +128,18 @@
     <string name="admin_status">Stav: %1$s</string>
     <string name="admin_code_label">Kód: %1$s</string>
 
+    <!-- Stand status labels -->
+    <string name="stand_status_active">Aktívny</string>
+    <string name="stand_status_technical">Technický</string>
+    <string name="stand_status_hidden">Skrytý</string>
+    <string name="stand_status_inactive">Neaktívny</string>
+    <string name="stand_status_virtual">Virtuálny</string>
+
+    <!-- Bike status labels -->
+    <string name="bike_status_problematic">Problémový</string>
+    <string name="bike_status_rented">Požičaný</string>
+    <string name="bike_status_ok">OK</string>
+
     <!-- Update notification -->
     <string name="update_available">Je dostupná nová verzia %1$s</string>
     <string name="update_download">Stiahnuť</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -128,6 +128,18 @@
     <string name="admin_status">Статус: %1$s</string>
     <string name="admin_code_label">Код: %1$s</string>
 
+    <!-- Stand status labels -->
+    <string name="stand_status_active">Активний</string>
+    <string name="stand_status_technical">Технічний</string>
+    <string name="stand_status_hidden">Прихований</string>
+    <string name="stand_status_inactive">Неактивний</string>
+    <string name="stand_status_virtual">Віртуальний</string>
+
+    <!-- Bike status labels -->
+    <string name="bike_status_problematic">Проблемний</string>
+    <string name="bike_status_rented">Орендований</string>
+    <string name="bike_status_ok">OK</string>
+
     <!-- Update notification -->
     <string name="update_available">Доступна нова версія %1$s</string>
     <string name="update_download">Завантажити</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,6 +128,18 @@
     <string name="admin_status">Status: %1$s</string>
     <string name="admin_code_label">Code: %1$s</string>
 
+    <!-- Stand status labels -->
+    <string name="stand_status_active">Active</string>
+    <string name="stand_status_technical">Technical</string>
+    <string name="stand_status_hidden">Hidden (testing)</string>
+    <string name="stand_status_inactive">Inactive</string>
+    <string name="stand_status_virtual">Virtual</string>
+
+    <!-- Bike status labels -->
+    <string name="bike_status_problematic">Problematic</string>
+    <string name="bike_status_rented">Rented</string>
+    <string name="bike_status_ok">OK</string>
+
     <!-- Update notification -->
     <string name="update_available">New version %1$s available</string>
     <string name="update_download">Download</string>


### PR DESCRIPTION
## Summary

Brings the Android admin screens to feature parity with the web admin tabs. Before this PR:

- Bikes: free-text search only, no status filter, every card looked the same.
- Stands: cards rendered without showing the status field at all, no filter, no color coding.

Now both screens have the same status-filter UX as the web admin (PR #326 on the web repo).

## Stands

- Filter chip row with five statuses (`active` / `technical` / `hidden` / `inactive` / `virtual`). Empty selection shows everything; click a chip to narrow down.
- Card header strip uses the palette mirroring the web admin (`bg-success` / `bg-warning` / `bg-info` / `bg-secondary` / `bg-primary`). Status name shown in the header — previously not displayed on Android at all.
- Material icons on the filter chips: `Place` / `Build` / `VisibilityOff` / `Block` / `Public`, mirroring the FontAwesome icons used on web.

## Bikes

- Filter chip row for `problematic` / `rented` / `ok`, same empty-shows-all semantics.
- Card container color tinted by derived status (`rented` → green, `notes != null` → orange, else surface-grey), matching `bg-success` / `bg-warning` / `bg-light` on web.
- Status is derived client-side from existing fields (`userName`, `notes`) — no new API contract.

## Implementation

- `StatusColors.kt` — single source of truth for both palettes.
- `toggleStatusFilter()` in both view models flips a `Set<String>`. Not persisted (no DataStore in the project); matches the rest of the admin UX.
- `derivedStatus()` extension on `BikeDetailDto`.
- `uk` + `sk` translations for all new labels (lint `MissingTranslation` check would otherwise fail).

## Test plan

- [x] `./gradlew compileDebugKotlin` — clean (only pre-existing `hiltViewModel` deprecation warnings, not introduced here).
- [x] `./gradlew testDebugUnitTest :app:lintDebug` — green.
- [x] `./gradlew assembleDebug` — APK built.
- [ ] Manual on a debug build:
  - Admin → Stands tab. Cards now show status in colored header.
  - Toggle a chip — list narrows. Untoggle all — full list back.
  - Admin → Bikes tab. Cards are tinted by status.
  - Search box still works on top of the chip filter.