### PR TITLE
feat: highlight problematic bikes + theme/language settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,6 +105,7 @@ android {
 dependencies {
     // AndroidX Core
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.BikeShare">

--- a/app/src/main/java/com/bikeshare/app/MainActivity.kt
+++ b/app/src/main/java/com/bikeshare/app/MainActivity.kt
@@ -5,21 +5,28 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.bikeshare.app.data.local.UserPreferences
 import com.bikeshare.app.notification.FreeTimeNotificationWorker
 import com.bikeshare.app.ui.navigation.AppNavGraph
 import com.bikeshare.app.ui.theme.BikeShareTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var userPreferences: UserPreferences
 
     private val requestNotificationPermission = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
@@ -44,7 +51,9 @@ class MainActivity : ComponentActivity() {
             consumeIntent(intent)
         }
         setContent {
-            BikeShareTheme {
+            val themeFlow = remember(userPreferences) { userPreferences.themeModeFlow() }
+            val themeMode by themeFlow.collectAsStateWithLifecycle(initialValue = userPreferences.themeMode)
+            BikeShareTheme(themeMode = themeMode) {
                 AppNavGraph(
                     navigateTo = pendingNavigation,
                     pendingQrUrl = pendingQrUrl,

--- a/app/src/main/java/com/bikeshare/app/data/local/UserPreferences.kt
+++ b/app/src/main/java/com/bikeshare/app/data/local/UserPreferences.kt
@@ -1,0 +1,52 @@
+package com.bikeshare.app.data.local
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+enum class ThemeMode { SYSTEM, LIGHT, DARK }
+
+@Singleton
+class UserPreferences @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("bikeshare_user_prefs", Context.MODE_PRIVATE)
+
+    var themeMode: ThemeMode
+        get() {
+            val name = prefs.getString(KEY_THEME_MODE, null) ?: return ThemeMode.SYSTEM
+            return ThemeMode.entries.firstOrNull { it.name == name } ?: ThemeMode.SYSTEM
+        }
+        set(value) {
+            prefs.edit().putString(KEY_THEME_MODE, value.name).apply()
+        }
+
+    // Survives the Activity recreation that AppCompatDelegate.setApplicationLocales
+    // triggers, so the confirmation snackbar renders in the newly-applied locale.
+    var languageChangePending: Boolean
+        get() = prefs.getBoolean(KEY_LANGUAGE_CHANGE_PENDING, false)
+        set(value) {
+            prefs.edit().putBoolean(KEY_LANGUAGE_CHANGE_PENDING, value).apply()
+        }
+
+    fun themeModeFlow(): Flow<ThemeMode> = callbackFlow {
+        trySend(themeMode)
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == KEY_THEME_MODE) trySend(themeMode)
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }.distinctUntilChanged()
+
+    companion object {
+        private const val KEY_THEME_MODE = "theme_mode"
+        private const val KEY_LANGUAGE_CHANGE_PENDING = "language_change_pending"
+    }
+}

--- a/app/src/main/java/com/bikeshare/app/di/AppModule.kt
+++ b/app/src/main/java/com/bikeshare/app/di/AppModule.kt
@@ -2,6 +2,7 @@ package com.bikeshare.app.di
 
 import android.content.Context
 import com.bikeshare.app.data.local.TokenStorage
+import com.bikeshare.app.data.local.UserPreferences
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,5 +18,11 @@ object AppModule {
     @Singleton
     fun provideTokenStorage(@ApplicationContext context: Context): TokenStorage {
         return TokenStorage(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideUserPreferences(@ApplicationContext context: Context): UserPreferences {
+        return UserPreferences(context)
     }
 }

--- a/app/src/main/java/com/bikeshare/app/ui/map/StandBottomSheet.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/StandBottomSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -100,12 +101,27 @@ fun StandBottomSheet(
     }
 }
 
+private val ProblematicBikeContainer = Color(0xFFFFF3CD)
+private val ProblematicBikeContent = Color(0xFF664D03)
+
 @Composable
 private fun BikeItem(
     bike: BikeOnStandDto,
     onRent: () -> Unit,
 ) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+    val hasNotes = !bike.notes.isNullOrBlank()
+    val cardColors = if (hasNotes) {
+        CardDefaults.cardColors(
+            containerColor = ProblematicBikeContainer,
+            contentColor = ProblematicBikeContent,
+        )
+    } else {
+        CardDefaults.cardColors()
+    }
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = cardColors,
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -120,7 +136,7 @@ private fun BikeItem(
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.DirectionsBike,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = if (hasNotes) ProblematicBikeContent else MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(28.dp),
                 )
                 Spacer(modifier = Modifier.width(8.dp))
@@ -139,13 +155,13 @@ private fun BikeItem(
                                 imageVector = Icons.Default.Warning,
                                 contentDescription = null,
                                 modifier = Modifier.size(14.dp).padding(top = 2.dp),
-                                tint = MaterialTheme.colorScheme.error,
+                                tint = ProblematicBikeContent,
                             )
                             Spacer(modifier = Modifier.width(4.dp))
                             Text(
                                 text = note,
                                 style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.error,
+                                color = ProblematicBikeContent,
                                 modifier = Modifier.weight(1f, fill = true),
                             )
                         }

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -40,6 +40,7 @@ import com.bikeshare.app.ui.map.MapViewModel
 import com.bikeshare.app.ui.rental.RentalScreen
 import com.bikeshare.app.ui.about.AboutScreen
 import com.bikeshare.app.ui.profile.ProfileScreen
+import com.bikeshare.app.ui.settings.SettingsScreen
 import com.bikeshare.app.ui.credit.CreditScreen
 import com.bikeshare.app.ui.credithistory.CreditHistoryScreen
 import com.bikeshare.app.ui.trips.TripsScreen
@@ -242,6 +243,7 @@ fun AppNavGraph(
                     onNavigateToCreditHistory = { navController.navigate(Screen.CreditHistory.route) },
                     onNavigateToTrips = { navController.navigate(Screen.Trips.route) },
                     onNavigateToAbout = { navController.navigate(Screen.About.route) },
+                    onNavigateToSettings = { navController.navigate(Screen.Settings.route) },
                     onLogout = {
                         navController.navigate(Screen.Login.route) {
                             popUpTo(0) { inclusive = true }
@@ -264,6 +266,10 @@ fun AppNavGraph(
 
             composable(Screen.About.route) {
                 AboutScreen(onBack = { navController.popBackStack() })
+            }
+
+            composable(Screen.Settings.route) {
+                SettingsScreen(onBack = { navController.popBackStack() })
             }
 
             composable(Screen.QrScanner.route) { entry ->

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/Screen.kt
@@ -12,6 +12,7 @@ sealed class Screen(val route: String) {
     data object Trips : Screen("trips")
     data object QrScanner : Screen("qr_scanner")
     data object About : Screen("about")
+    data object Settings : Screen("settings")
 
     // Admin
     data object AdminDashboard : Screen("admin/dashboard")

--- a/app/src/main/java/com/bikeshare/app/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/profile/ProfileScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.CreditCard
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -23,6 +24,7 @@ fun ProfileScreen(
     onNavigateToCreditHistory: () -> Unit,
     onNavigateToTrips: () -> Unit,
     onNavigateToAbout: () -> Unit,
+    onNavigateToSettings: () -> Unit,
     onLogout: () -> Unit,
     viewModel: ProfileViewModel = hiltViewModel(),
 ) {
@@ -46,6 +48,9 @@ fun ProfileScreen(
             TopAppBar(
                 title = { Text(stringResource(R.string.nav_profile)) },
                 actions = {
+                    IconButton(onClick = onNavigateToSettings) {
+                        Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.settings_title))
+                    }
                     IconButton(onClick = { viewModel.logout() }) {
                         Icon(Icons.AutoMirrored.Filled.Logout, contentDescription = stringResource(R.string.logout))
                     }
@@ -144,6 +149,15 @@ fun ProfileScreen(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.recent_trips))
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedButton(
+                onClick = onNavigateToSettings,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.settings_title))
             }
 
             Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/bikeshare/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/settings/SettingsScreen.kt
@@ -1,0 +1,173 @@
+package com.bikeshare.app.ui.settings
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.bikeshare.app.R
+import com.bikeshare.app.data.local.ThemeMode
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    onBack: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val languageChangedMessage = stringResource(R.string.settings_language_changed)
+
+    LaunchedEffect(Unit) {
+        if (viewModel.consumeLanguageChangePending()) {
+            snackbarHostState.showSnackbar(languageChangedMessage)
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+        ) {
+            ChoiceSection(
+                icon = Icons.Default.DarkMode,
+                titleRes = R.string.settings_theme,
+                entries = ThemeMode.entries,
+                selected = uiState.themeMode,
+                label = ::themeLabel,
+                onSelect = viewModel::setThemeMode,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            ChoiceSection(
+                icon = Icons.Default.Language,
+                titleRes = R.string.settings_language,
+                entries = AppLanguage.entries,
+                selected = uiState.language,
+                label = ::languageLabel,
+                onSelect = viewModel::setLanguage,
+            )
+        }
+    }
+}
+
+@Composable
+private fun <T> ChoiceSection(
+    icon: ImageVector,
+    @StringRes titleRes: Int,
+    entries: List<T>,
+    selected: T,
+    label: (T) -> Int,
+    onSelect: (T) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(bottom = 8.dp),
+    ) {
+        Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+        Spacer(modifier = Modifier.size(8.dp))
+        Text(
+            text = stringResource(titleRes),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.selectableGroup()) {
+            entries.forEach { entry ->
+                OptionRow(
+                    selected = entry == selected,
+                    labelRes = label(entry),
+                    onClick = { onSelect(entry) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OptionRow(
+    selected: Boolean,
+    @StringRes labelRes: Int,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                onClick = onClick,
+                role = Role.RadioButton,
+            )
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = null)
+        Spacer(modifier = Modifier.size(12.dp))
+        Text(stringResource(labelRes))
+    }
+}
+
+@StringRes
+private fun themeLabel(mode: ThemeMode): Int = when (mode) {
+    ThemeMode.SYSTEM -> R.string.settings_theme_system
+    ThemeMode.LIGHT -> R.string.settings_theme_light
+    ThemeMode.DARK -> R.string.settings_theme_dark
+}
+
+@StringRes
+private fun languageLabel(language: AppLanguage): Int = when (language) {
+    AppLanguage.SYSTEM -> R.string.settings_language_system
+    AppLanguage.ENGLISH -> R.string.settings_language_english
+    AppLanguage.SLOVAK -> R.string.settings_language_slovak
+    AppLanguage.UKRAINIAN -> R.string.settings_language_ukrainian
+}

--- a/app/src/main/java/com/bikeshare/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,66 @@
+package com.bikeshare.app.ui.settings
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import androidx.lifecycle.ViewModel
+import com.bikeshare.app.data.local.ThemeMode
+import com.bikeshare.app.data.local.UserPreferences
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+// `tag = null` clears the per-app locale override (follow system).
+enum class AppLanguage(val tag: String?) {
+    SYSTEM(null),
+    ENGLISH("en"),
+    SLOVAK("sk"),
+    UKRAINIAN("uk"),
+}
+
+data class SettingsUiState(
+    val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    val language: AppLanguage = AppLanguage.SYSTEM,
+)
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val userPreferences: UserPreferences,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        SettingsUiState(
+            themeMode = userPreferences.themeMode,
+            language = currentLanguage(),
+        ),
+    )
+    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    fun setThemeMode(mode: ThemeMode) {
+        userPreferences.themeMode = mode
+        _uiState.value = _uiState.value.copy(themeMode = mode)
+    }
+
+    fun setLanguage(language: AppLanguage) {
+        if (language == _uiState.value.language) return
+        val locales = language.tag?.let { LocaleListCompat.forLanguageTags(it) }
+            ?: LocaleListCompat.getEmptyLocaleList()
+        userPreferences.languageChangePending = true
+        AppCompatDelegate.setApplicationLocales(locales)
+        _uiState.value = _uiState.value.copy(language = language)
+    }
+
+    fun consumeLanguageChangePending(): Boolean {
+        val pending = userPreferences.languageChangePending
+        if (pending) userPreferences.languageChangePending = false
+        return pending
+    }
+
+    private fun currentLanguage(): AppLanguage {
+        val current = AppCompatDelegate.getApplicationLocales()
+        if (current.isEmpty) return AppLanguage.SYSTEM
+        val tag = current[0]?.language ?: return AppLanguage.SYSTEM
+        return AppLanguage.entries.firstOrNull { it.tag == tag } ?: AppLanguage.SYSTEM
+    }
+}

--- a/app/src/main/java/com/bikeshare/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/theme/Theme.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import com.bikeshare.app.data.local.ThemeMode
 
 private val LightColorScheme = lightColorScheme(
     primary = Blue500,
@@ -44,9 +45,14 @@ private val DarkColorScheme = darkColorScheme(
 
 @Composable
 fun BikeShareTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    themeMode: ThemeMode = ThemeMode.SYSTEM,
     content: @Composable () -> Unit,
 ) {
+    val darkTheme = when (themeMode) {
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+    }
     val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
 
     val view = LocalView.current

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -144,6 +144,19 @@
     <string name="update_available">Je dostupná nová verzia %1$s</string>
     <string name="update_download">Stiahnuť</string>
 
+    <!-- Settings screen -->
+    <string name="settings_title">Nastavenia</string>
+    <string name="settings_theme">Téma</string>
+    <string name="settings_theme_system">Podľa systému</string>
+    <string name="settings_theme_light">Svetlá</string>
+    <string name="settings_theme_dark">Tmavá</string>
+    <string name="settings_language">Jazyk</string>
+    <string name="settings_language_system">Systémový</string>
+    <string name="settings_language_english">English</string>
+    <string name="settings_language_slovak">Slovenčina</string>
+    <string name="settings_language_ukrainian">Українська</string>
+    <string name="settings_language_changed">Jazyk bol zmenený</string>
+
     <!-- About screen -->
     <string name="about_title">O aplikácii</string>
     <string name="about_menu">O aplikácii</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -144,6 +144,19 @@
     <string name="update_available">Доступна нова версія %1$s</string>
     <string name="update_download">Завантажити</string>
 
+    <!-- Settings screen -->
+    <string name="settings_title">Налаштування</string>
+    <string name="settings_theme">Тема</string>
+    <string name="settings_theme_system">Як у системі</string>
+    <string name="settings_theme_light">Світла</string>
+    <string name="settings_theme_dark">Темна</string>
+    <string name="settings_language">Мова</string>
+    <string name="settings_language_system">Системна</string>
+    <string name="settings_language_english">English</string>
+    <string name="settings_language_slovak">Slovenčina</string>
+    <string name="settings_language_ukrainian">Українська</string>
+    <string name="settings_language_changed">Мову змінено</string>
+
     <!-- About screen -->
     <string name="about_title">Про додаток</string>
     <string name="about_menu">Про додаток</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,19 @@
     <string name="update_available">New version %1$s available</string>
     <string name="update_download">Download</string>
 
+    <!-- Settings screen -->
+    <string name="settings_title">Settings</string>
+    <string name="settings_theme">Theme</string>
+    <string name="settings_theme_system">Follow system</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_system">System default</string>
+    <string name="settings_language_english">English</string>
+    <string name="settings_language_slovak">Slovenčina</string>
+    <string name="settings_language_ukrainian">Українська</string>
+    <string name="settings_language_changed">Language updated</string>
+
     <!-- About screen -->
     <string name="about_title">About</string>
     <string name="about_menu">About</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.BikeShare" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.BikeShare" parent="Theme.AppCompat.DayNight.NoActionBar" />
 </resources>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="sk" />
+    <locale android:name="uk" />
+</locale-config>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "9.2.1"
 kotlin = "2.3.21"
 coreKtx = "1.18.0"
+appcompat = "1.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
 composeBom = "2026.05.01"
@@ -34,6 +35,7 @@ ksp = "2.3.7"
 [libraries]
 # AndroidX Core
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }


### PR DESCRIPTION
## Summary

- Bikes with notes on a stand now render with a soft yellow card (Bootstrap alert-warning palette) so users can spot issues before tapping Rent.
- New Settings screen (Profile → Settings, or the gear icon in the Profile TopAppBar) lets users override Theme (System/Light/Dark) and Language (System/EN/SK/UK).
- Language change triggers an Activity recreation via `AppCompatDelegate.setApplicationLocales`; a pending-snackbar flag in prefs survives the recreate and confirms the new language in the newly-applied locale.

Infra: added `androidx.appcompat:1.7.0`; `MainActivity` is now `AppCompatActivity`; base theme switched to `Theme.AppCompat.DayNight.NoActionBar` (Compose still owns colors). `android:localeConfig` declared so Android 13+ exposes the per-app language picker in system settings.

## Test plan

- [ ] Open a stand with a bike that has notes — card is yellow, note + warning icon are readable
- [ ] Profile → Settings via both the list button and the new gear icon
- [ ] Theme: switch System → Light → Dark; verify status bar and surfaces follow each pick and the choice survives app restart
- [ ] Language: switch System → English → Slovak → Ukrainian; confirmation snackbar appears in the new locale; choice survives restart
- [ ] Repeat language switch on an Android ≤ 12 device (AppCompat path) and Android 13+ device (system path)
- [ ] System settings → app → Language shows the picker on Android 13+