### PR TITLE
Drop phoneConfirmed flag, react to 403 phone_unconfirmed (spec 0002)

### DIFF
--- a/app/src/main/java/com/bikeshare/app/data/api/PhoneUnconfirmedInterceptor.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/PhoneUnconfirmedInterceptor.kt
@@ -1,0 +1,47 @@
+package com.bikeshare.app.data.api
+
+import com.bikeshare.app.util.SessionEvent
+import com.bikeshare.app.util.SessionEventBus
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.json.JSONException
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * Detects the server's "phone not confirmed" gate — a 403 carrying
+ * `code: phone_unconfirmed` (spec 0001) — and emits a [SessionEvent] so the UI can
+ * route to the verify screen. The body is peeked (not consumed), so downstream
+ * parsing is unaffected. Only this specific code triggers it; a generic 403 does not.
+ */
+class PhoneUnconfirmedInterceptor @Inject constructor(
+    private val sessionEventBus: SessionEventBus,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+        if (response.code == HTTP_FORBIDDEN) {
+            val body = response.peekBody(MAX_PEEK_BYTES).string()
+            if (isPhoneUnconfirmed(body)) {
+                sessionEventBus.emit(SessionEvent.PhoneUnconfirmed)
+            }
+        }
+        return response
+    }
+
+    companion object {
+        private const val HTTP_FORBIDDEN = 403
+        private const val MAX_PEEK_BYTES = 4096L
+        const val CODE_PHONE_UNCONFIRMED = "phone_unconfirmed"
+
+        /** True when the (problem+json) error body carries `code = phone_unconfirmed`. */
+        fun isPhoneUnconfirmed(body: String?): Boolean {
+            if (body.isNullOrBlank()) return false
+            return try {
+                JSONObject(body).optString("code") == CODE_PHONE_UNCONFIRMED
+            } catch (_: JSONException) {
+                false
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bikeshare/app/data/api/TokenRefreshAuthenticator.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/TokenRefreshAuthenticator.kt
@@ -35,7 +35,6 @@ class TokenRefreshAuthenticator @Inject constructor(
             tokenStorage.saveTokens(
                 newTokens.accessToken,
                 newTokens.refreshToken,
-                newTokens.phoneConfirmed != false,
             )
             response.request.newBuilder()
                 .header("Authorization", "Bearer ${newTokens.accessToken}")

--- a/app/src/main/java/com/bikeshare/app/data/api/dto/AuthDto.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/dto/AuthDto.kt
@@ -23,7 +23,6 @@ data class LogoutRequest(
 data class AuthTokens(
     @Json(name = "accessToken") val accessToken: String,
     @Json(name = "refreshToken") val refreshToken: String,
-    @Json(name = "phoneConfirmed") val phoneConfirmed: Boolean? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/bikeshare/app/data/local/TokenStorage.kt
+++ b/app/src/main/java/com/bikeshare/app/data/local/TokenStorage.kt
@@ -31,18 +31,15 @@ class TokenStorage @Inject constructor(
     companion object {
         private const val KEY_ACCESS_TOKEN = "access_token"
         private const val KEY_REFRESH_TOKEN = "refresh_token"
-        private const val KEY_PHONE_CONFIRMED = "phone_confirmed"
     }
 
     fun saveTokens(
         accessToken: String,
         refreshToken: String,
-        phoneConfirmed: Boolean = true,
     ) {
         prefs.edit()
             .putString(KEY_ACCESS_TOKEN, accessToken)
             .putString(KEY_REFRESH_TOKEN, refreshToken)
-            .putBoolean(KEY_PHONE_CONFIRMED, phoneConfirmed)
             .apply()
     }
 
@@ -50,17 +47,10 @@ class TokenStorage @Inject constructor(
 
     fun getRefreshToken(): String? = prefs.getString(KEY_REFRESH_TOKEN, null)
 
-    fun getPhoneConfirmed(): Boolean = prefs.getBoolean(KEY_PHONE_CONFIRMED, true)
-
-    fun setPhoneConfirmed(confirmed: Boolean) {
-        prefs.edit().putBoolean(KEY_PHONE_CONFIRMED, confirmed).apply()
-    }
-
     fun clearTokens() {
         prefs.edit()
             .remove(KEY_ACCESS_TOKEN)
             .remove(KEY_REFRESH_TOKEN)
-            .remove(KEY_PHONE_CONFIRMED)
             .apply()
     }
 

--- a/app/src/main/java/com/bikeshare/app/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/bikeshare/app/data/repository/AuthRepositoryImpl.kt
@@ -20,24 +20,20 @@ class AuthRepositoryImpl @Inject constructor(
     private val moshi: Moshi,
 ) : AuthRepository {
 
-    override suspend fun login(number: String, password: String): NetworkResult<Boolean> {
+    override suspend fun login(number: String, password: String): NetworkResult<Unit> {
         val result = safeApiCall(moshi) { api.login(TokenRequest(number, password)) }
         return when (result) {
             is NetworkResult.Success -> {
-                val phoneConfirmed = result.data.phoneConfirmed != false
                 tokenStorage.saveTokens(
                     result.data.accessToken,
                     result.data.refreshToken,
-                    phoneConfirmed,
                 )
-                NetworkResult.Success(phoneConfirmed)
+                NetworkResult.Success(Unit)
             }
             is NetworkResult.Error -> result
             is NetworkResult.Loading -> result
         }
     }
-
-    override suspend fun getPhoneConfirmed(): Boolean = tokenStorage.getPhoneConfirmed()
 
     override suspend fun logout(): NetworkResult<Unit> {
         val refreshToken = tokenStorage.getRefreshToken()

--- a/app/src/main/java/com/bikeshare/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/bikeshare/app/di/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.bikeshare.app.di
 import com.bikeshare.app.BuildConfig
 import com.bikeshare.app.data.api.ApiService
 import com.bikeshare.app.data.api.AuthInterceptor
+import com.bikeshare.app.data.api.PhoneUnconfirmedInterceptor
 import com.bikeshare.app.data.api.TokenRefreshAuthenticator
 import com.squareup.moshi.Moshi
 import io.sentry.okhttp.SentryOkHttpInterceptor
@@ -29,6 +30,7 @@ object NetworkModule {
     @Singleton
     fun provideOkHttpClient(
         authInterceptor: AuthInterceptor,
+        phoneUnconfirmedInterceptor: PhoneUnconfirmedInterceptor,
         tokenRefreshAuthenticator: TokenRefreshAuthenticator,
     ): OkHttpClient {
         val builder = OkHttpClient.Builder()
@@ -39,6 +41,7 @@ object NetworkModule {
                 chain.proceed(request)
             }
             .addInterceptor(authInterceptor)
+            .addInterceptor(phoneUnconfirmedInterceptor)
             .authenticator(tokenRefreshAuthenticator)
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)

--- a/app/src/main/java/com/bikeshare/app/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/bikeshare/app/domain/repository/AuthRepository.kt
@@ -4,11 +4,10 @@ import com.bikeshare.app.domain.model.MessengerChat
 import com.bikeshare.app.util.NetworkResult
 
 interface AuthRepository {
-    suspend fun login(number: String, password: String): NetworkResult<Boolean>
+    suspend fun login(number: String, password: String): NetworkResult<Unit>
 
     suspend fun logout(): NetworkResult<Unit>
     suspend fun isLoggedIn(): Boolean
-    suspend fun getPhoneConfirmed(): Boolean
     suspend fun getCities(): NetworkResult<List<String>>
     suspend fun getMessengerChats(): NetworkResult<List<MessengerChat>>
     suspend fun register(

--- a/app/src/main/java/com/bikeshare/app/ui/auth/LoginScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/auth/LoginScreen.kt
@@ -27,7 +27,7 @@ import com.bikeshare.app.R
 
 @Composable
 fun LoginScreen(
-    onLoginSuccess: (phoneConfirmed: Boolean) -> Unit,
+    onLoginSuccess: () -> Unit,
     onNavigateToRegister: () -> Unit = {},
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
@@ -39,7 +39,7 @@ fun LoginScreen(
 
     LaunchedEffect(uiState.isSuccess) {
         if (uiState.isSuccess) {
-            onLoginSuccess(uiState.phoneConfirmed)
+            onLoginSuccess()
         }
     }
 

--- a/app/src/main/java/com/bikeshare/app/ui/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/auth/LoginViewModel.kt
@@ -13,7 +13,6 @@ import javax.inject.Inject
 data class LoginUiState(
     val isLoading: Boolean = false,
     val isSuccess: Boolean = false,
-    val phoneConfirmed: Boolean = true,
     val error: String? = null,
 )
 
@@ -32,8 +31,7 @@ class LoginViewModel @Inject constructor(
     private fun checkExistingSession() {
         viewModelScope.launch {
             if (authRepository.isLoggedIn()) {
-                val phoneConfirmed = authRepository.getPhoneConfirmed()
-                _uiState.value = LoginUiState(isSuccess = true, phoneConfirmed = phoneConfirmed)
+                _uiState.value = LoginUiState(isSuccess = true)
             }
         }
     }
@@ -43,10 +41,7 @@ class LoginViewModel @Inject constructor(
             _uiState.value = LoginUiState(isLoading = true)
             when (val result = authRepository.login(number, password)) {
                 is NetworkResult.Success -> {
-                    _uiState.value = LoginUiState(
-                        isSuccess = true,
-                        phoneConfirmed = result.data,
-                    )
+                    _uiState.value = LoginUiState(isSuccess = true)
                 }
                 is NetworkResult.Error -> {
                     _uiState.value = LoginUiState(error = result.message)

--- a/app/src/main/java/com/bikeshare/app/ui/auth/PhoneVerifyViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/auth/PhoneVerifyViewModel.kt
@@ -2,7 +2,6 @@ package com.bikeshare.app.ui.auth
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.bikeshare.app.data.local.TokenStorage
 import com.bikeshare.app.domain.repository.AuthRepository
 import com.bikeshare.app.util.NetworkResult
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -23,7 +22,6 @@ data class PhoneVerifyUiState(
 @HiltViewModel
 class PhoneVerifyViewModel @Inject constructor(
     private val authRepository: AuthRepository,
-    private val tokenStorage: TokenStorage,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(PhoneVerifyUiState())
@@ -60,7 +58,6 @@ class PhoneVerifyViewModel @Inject constructor(
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
             when (val result = authRepository.verifyPhoneConfirm(sanitized, checkCode)) {
                 is NetworkResult.Success -> {
-                    tokenStorage.setPhoneConfirmed(true)
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
                         isSuccess = true,

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -32,6 +32,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.bikeshare.app.R
 import com.bikeshare.app.notification.FreeTimeNotificationWorker
+import com.bikeshare.app.util.SessionEvent
 import com.bikeshare.app.ui.auth.LoginScreen
 import com.bikeshare.app.ui.auth.PhoneVerifyScreen
 import com.bikeshare.app.ui.auth.RegisterScreen
@@ -86,6 +87,23 @@ fun AppNavGraph(
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // The server gates unconfirmed-phone users with a 403 phone_unconfirmed (spec 0001);
+    // the network layer surfaces it as a SessionEvent. Route to the verify screen
+    // reactively, from wherever the user is.
+    LaunchedEffect(Unit) {
+        appViewModel.sessionEvents.collect { event ->
+            when (event) {
+                SessionEvent.PhoneUnconfirmed -> {
+                    if (navController.currentDestination?.route != Screen.PhoneVerify.route) {
+                        navController.navigate(Screen.PhoneVerify.route) {
+                            launchSingleTop = true
+                        }
+                    }
+                }
+            }
+        }
     }
 
     LaunchedEffect(navigateTo) {
@@ -201,10 +219,8 @@ fun AppNavGraph(
         ) {
             composable(Screen.Login.route) {
                 LoginScreen(
-                    onLoginSuccess = { phoneConfirmed ->
-                        navController.navigate(
-                            if (phoneConfirmed) Screen.Map.route else Screen.PhoneVerify.route,
-                        ) {
+                    onLoginSuccess = {
+                        navController.navigate(Screen.Map.route) {
                             popUpTo(Screen.Login.route) { inclusive = true }
                         }
                     },

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppViewModel.kt
@@ -9,9 +9,12 @@ import com.bikeshare.app.domain.update.UpdateChecker
 import com.bikeshare.app.domain.update.UpdateInfo
 import com.bikeshare.app.notification.FreeTimeNotificationScheduler
 import com.bikeshare.app.util.NetworkResult
+import com.bikeshare.app.util.SessionEvent
+import com.bikeshare.app.util.SessionEventBus
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -22,7 +25,11 @@ class AppViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val rentalRepository: RentalRepository,
     private val updateChecker: UpdateChecker,
+    sessionEventBus: SessionEventBus,
 ) : ViewModel() {
+
+    /** Session events surfaced from the network layer (e.g. phone-unconfirmed gate). */
+    val sessionEvents: SharedFlow<SessionEvent> = sessionEventBus.events
 
     private val _isAdmin = MutableStateFlow(false)
     val isAdmin: StateFlow<Boolean> = _isAdmin.asStateFlow()

--- a/app/src/main/java/com/bikeshare/app/util/SessionEventBus.kt
+++ b/app/src/main/java/com/bikeshare/app/util/SessionEventBus.kt
@@ -1,0 +1,28 @@
+package com.bikeshare.app.util
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** App-wide, session-scoped events surfaced from the network layer to the UI. */
+sealed interface SessionEvent {
+    /** The server rejected a request because the user's phone is not confirmed. */
+    data object PhoneUnconfirmed : SessionEvent
+}
+
+/**
+ * Single hop from the network layer (interceptors) to the UI (navigation). The UI
+ * observes [events] and reacts (e.g. routes to the phone-verify screen) without any
+ * ViewModel having to special-case the error.
+ */
+@Singleton
+class SessionEventBus @Inject constructor() {
+    private val _events = MutableSharedFlow<SessionEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<SessionEvent> = _events.asSharedFlow()
+
+    fun emit(event: SessionEvent) {
+        _events.tryEmit(event)
+    }
+}

--- a/app/src/test/java/com/bikeshare/app/data/api/PhoneUnconfirmedInterceptorTest.kt
+++ b/app/src/test/java/com/bikeshare/app/data/api/PhoneUnconfirmedInterceptorTest.kt
@@ -1,0 +1,39 @@
+package com.bikeshare.app.data.api
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+// Robolectric supplies a real org.json implementation (the JVM stub would throw).
+@RunWith(RobolectricTestRunner::class)
+class PhoneUnconfirmedInterceptorTest {
+
+    @Test
+    fun `detects phone_unconfirmed code in problem+json body`() {
+        val body = """
+            {"type":"about:blank","title":"Forbidden","status":403,
+             "detail":"Phone number must be confirmed.",
+             "instance":"/api/v1/me/bikes","requestId":"abc","code":"phone_unconfirmed"}
+        """.trimIndent()
+        assertTrue(PhoneUnconfirmedInterceptor.isPhoneUnconfirmed(body))
+    }
+
+    @Test
+    fun `ignores a generic forbidden body without the code`() {
+        assertFalse(PhoneUnconfirmedInterceptor.isPhoneUnconfirmed("""{"detail":"Access denied"}"""))
+    }
+
+    @Test
+    fun `ignores a different code`() {
+        assertFalse(PhoneUnconfirmedInterceptor.isPhoneUnconfirmed("""{"code":"something_else"}"""))
+    }
+
+    @Test
+    fun `ignores non-json, empty and null bodies`() {
+        assertFalse(PhoneUnconfirmedInterceptor.isPhoneUnconfirmed("not json at all"))
+        assertFalse(PhoneUnconfirmedInterceptor.isPhoneUnconfirmed(""))
+        assertFalse(PhoneUnconfirmedInterceptor.isPhoneUnconfirmed(null))
+    }
+}


### PR DESCRIPTION
## What & why

Implements spec **0002** (depends on web spec 0001, merged). Removes the cached
`phoneConfirmed` flag end-to-end and drives the phone-verify navigation
**reactively** from the server's `403 {code: "phone_unconfirmed"}` (spec 0001), so
the client no longer duplicates server-owned state (which could go stale).

## Changes

- **New `SessionEventBus`** (`util/`) — one hop from the network layer to the UI.
- **New `PhoneUnconfirmedInterceptor`** (`data/api/`) — on a `403`, peeks the body
  (non-consuming), and if `code == phone_unconfirmed` emits `SessionEvent.PhoneUnconfirmed`.
  Wired into the OkHttp client in `NetworkModule`.
- **`AppNavGraph`** collects the event and routes to the phone-verify screen
  (silent, single-top). Login now always lands on Map; a newbie's first call bounces
  to verify.
- **Removed `phoneConfirmed`** from `AuthTokens`, `TokenStorage`, `AuthRepository`(+Impl),
  `TokenRefreshAuthenticator`, `LoginViewModel`/`LoginScreen`, `PhoneVerifyViewModel`.

## Tests

- Unit `PhoneUnconfirmedInterceptorTest` — detects the code; ignores generic 403,
  other codes, non-JSON/empty/null (Robolectric for real `org.json`).
- `./gradlew :app:testDebugUnitTest` and `:app:lintDebug` both green (JDK 17).

## Notes

- Generic 403s do **not** trigger verify navigation (only `phone_unconfirmed`).
- Self-correcting: confirming elsewhere needs no client state sync.