### PR TITLE
Force-update screen on server 426 Upgrade Required (spec 0005)

### DIFF
--- a/app/src/main/java/com/bikeshare/app/data/api/UpgradeRequiredInterceptor.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/UpgradeRequiredInterceptor.kt
@@ -1,0 +1,31 @@
+package com.bikeshare.app.data.api
+
+import com.bikeshare.app.util.SessionEvent
+import com.bikeshare.app.util.SessionEventBus
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+/**
+ * Detects the server's force-update gate — a `426 Upgrade Required` returned when the
+ * client is below the configured minimum supported version (spec 0005) — and emits a
+ * [SessionEvent.UpdateRequired] so the UI can block with the force-update screen. The
+ * status code alone is unambiguous, so (unlike [PhoneUnconfirmedInterceptor]) the body
+ * is not inspected.
+ */
+class UpgradeRequiredInterceptor @Inject constructor(
+    private val sessionEventBus: SessionEventBus,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+        if (response.code == HTTP_UPGRADE_REQUIRED) {
+            sessionEventBus.emit(SessionEvent.UpdateRequired)
+        }
+        return response
+    }
+
+    companion object {
+        private const val HTTP_UPGRADE_REQUIRED = 426
+    }
+}

--- a/app/src/main/java/com/bikeshare/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/bikeshare/app/di/NetworkModule.kt
@@ -5,6 +5,7 @@ import com.bikeshare.app.data.api.ApiService
 import com.bikeshare.app.data.api.AuthInterceptor
 import com.bikeshare.app.data.api.PhoneUnconfirmedInterceptor
 import com.bikeshare.app.data.api.TokenRefreshAuthenticator
+import com.bikeshare.app.data.api.UpgradeRequiredInterceptor
 import com.squareup.moshi.Moshi
 import io.sentry.okhttp.SentryOkHttpInterceptor
 import dagger.Module
@@ -31,6 +32,7 @@ object NetworkModule {
     fun provideOkHttpClient(
         authInterceptor: AuthInterceptor,
         phoneUnconfirmedInterceptor: PhoneUnconfirmedInterceptor,
+        upgradeRequiredInterceptor: UpgradeRequiredInterceptor,
         tokenRefreshAuthenticator: TokenRefreshAuthenticator,
     ): OkHttpClient {
         val builder = OkHttpClient.Builder()
@@ -42,6 +44,7 @@ object NetworkModule {
             }
             .addInterceptor(authInterceptor)
             .addInterceptor(phoneUnconfirmedInterceptor)
+            .addInterceptor(upgradeRequiredInterceptor)
             .authenticator(tokenRefreshAuthenticator)
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)

--- a/app/src/main/java/com/bikeshare/app/domain/update/UpdateChecker.kt
+++ b/app/src/main/java/com/bikeshare/app/domain/update/UpdateChecker.kt
@@ -56,6 +56,23 @@ class UpdateChecker @Inject constructor(
         }
     }
 
+    /**
+     * The latest published GitHub release page URL, or null if the check is disabled or
+     * the fetch fails. Used by the force-update gate (spec 0005) as the download target —
+     * the server's `426` carries no URL, so the app sources it from GitHub like the soft
+     * update. Ignores the 24h throttle: the gate needs a target on demand.
+     */
+    suspend fun latestReleaseUrl(): String? {
+        if (BuildConfig.UPDATE_CHECK_URL.isBlank()) return null
+        val release = runCatching { api.getLatestRelease(BuildConfig.UPDATE_CHECK_URL) }
+            .onFailure { Timber.w(it, "Latest-release fetch threw") }
+            .getOrNull()
+            ?.takeIf { it.isSuccessful }
+            ?.body()
+            ?: return null
+        return release.htmlUrl
+    }
+
     private fun shouldCheckNow(): Boolean {
         val lastCheck = prefs.getLong(KEY_LAST_CHECK, 0L)
         return System.currentTimeMillis() - lastCheck >= CHECK_INTERVAL_MILLIS

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -42,6 +42,7 @@ import com.bikeshare.app.ui.rental.RentalScreen
 import com.bikeshare.app.ui.about.AboutScreen
 import com.bikeshare.app.ui.profile.ProfileScreen
 import com.bikeshare.app.ui.settings.SettingsScreen
+import com.bikeshare.app.ui.update.ForceUpdateScreen
 import com.bikeshare.app.ui.credit.CreditScreen
 import com.bikeshare.app.ui.credithistory.CreditHistoryScreen
 import com.bikeshare.app.ui.trips.TripsScreen
@@ -75,6 +76,7 @@ fun AppNavGraph(
     val currentDestination = navBackStackEntry?.destination
     val isAdmin by appViewModel.isAdmin.collectAsStateWithLifecycle(initialValue = false)
     val updateInfo by appViewModel.updateInfo.collectAsStateWithLifecycle(initialValue = null)
+    val forceUpdateUrl by appViewModel.forceUpdateUrl.collectAsStateWithLifecycle(initialValue = null)
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -87,6 +89,14 @@ fun AppNavGraph(
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // Below the minimum supported version (spec 0005): the server returned 426 and the
+    // network layer surfaced it as a SessionEvent. Block everything with the force-update
+    // screen — it supersedes the whole nav graph and bottom bar.
+    forceUpdateUrl?.let { url ->
+        ForceUpdateScreen(releaseUrl = url)
+        return
     }
 
     // The server gates unconfirmed-phone users with a 403 phone_unconfirmed (spec 0001);
@@ -102,6 +112,9 @@ fun AppNavGraph(
                         }
                     }
                 }
+                // UpdateRequired is handled by AppViewModel (sets forceUpdateUrl, which
+                // blocks above via ForceUpdateScreen); no navigation needed here.
+                SessionEvent.UpdateRequired -> Unit
             }
         }
     }

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppViewModel.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppViewModel.kt
@@ -3,6 +3,7 @@ package com.bikeshare.app.ui.navigation
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.bikeshare.app.BuildConfig
 import com.bikeshare.app.domain.repository.RentalRepository
 import com.bikeshare.app.domain.update.UpdateCheckResult
 import com.bikeshare.app.domain.update.UpdateChecker
@@ -36,6 +37,30 @@ class AppViewModel @Inject constructor(
 
     private val _updateInfo = MutableStateFlow<UpdateInfo?>(null)
     val updateInfo: StateFlow<UpdateInfo?> = _updateInfo.asStateFlow()
+
+    /**
+     * Non-null (a download URL) once the server has rejected a request with `426 Upgrade
+     * Required` (spec 0005); the UI then blocks with the force-update screen. The gate is
+     * server-enforced — we only react to it here. Once set it stays until the process
+     * restarts on a new version.
+     */
+    private val _forceUpdateUrl = MutableStateFlow<String?>(null)
+    val forceUpdateUrl: StateFlow<String?> = _forceUpdateUrl.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            sessionEventBus.events.collect { event ->
+                if (event is SessionEvent.UpdateRequired) onUpdateRequired()
+            }
+        }
+    }
+
+    private suspend fun onUpdateRequired() {
+        if (_forceUpdateUrl.value != null) return
+        // The 426 carries no URL — the download target is the latest GitHub release,
+        // same source as the soft update. Fall back to the website if that fetch fails.
+        _forceUpdateUrl.value = updateChecker.latestReleaseUrl() ?: BuildConfig.WEBSITE_URL
+    }
 
     fun checkForUpdate() {
         viewModelScope.launch {

--- a/app/src/main/java/com/bikeshare/app/ui/update/ForceUpdateScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/update/ForceUpdateScreen.kt
@@ -1,0 +1,93 @@
+package com.bikeshare.app.ui.update
+
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.decode.SvgDecoder
+import coil.request.ImageRequest
+import com.bikeshare.app.BuildConfig
+import com.bikeshare.app.R
+
+/**
+ * Blocking, non-dismissible screen shown when the client is below the minimum supported
+ * version (spec 0005). Back is disabled and nothing else is reachable — the only action
+ * is to open the release download.
+ */
+@Composable
+fun ForceUpdateScreen(releaseUrl: String) {
+    // Swallow back: there is nowhere to go until the user updates.
+    BackHandler {}
+
+    val context = LocalContext.current
+
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            if (BuildConfig.LOGO_URL.isNotBlank()) {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(BuildConfig.LOGO_URL)
+                        .decoderFactory(SvgDecoder.Factory())
+                        .build(),
+                    contentDescription = null,
+                    modifier = Modifier.size(96.dp),
+                    contentScale = ContentScale.Fit,
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
+            Text(
+                text = stringResource(R.string.force_update_title),
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = stringResource(R.string.force_update_message),
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Button(
+                onClick = {
+                    context.startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse(releaseUrl))
+                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                    )
+                },
+            ) {
+                Text(stringResource(R.string.update_download))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bikeshare/app/util/SessionEventBus.kt
+++ b/app/src/main/java/com/bikeshare/app/util/SessionEventBus.kt
@@ -10,6 +10,12 @@ import javax.inject.Singleton
 sealed interface SessionEvent {
     /** The server rejected a request because the user's phone is not confirmed. */
     data object PhoneUnconfirmed : SessionEvent
+
+    /**
+     * The server rejected a request with `426 Upgrade Required` because the client is
+     * below the configured minimum supported version (spec 0005). The UI must block.
+     */
+    data object UpdateRequired : SessionEvent
 }
 
 /**

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -143,6 +143,8 @@
     <!-- Update notification -->
     <string name="update_available">Je dostupná nová verzia %1$s</string>
     <string name="update_download">Stiahnuť</string>
+    <string name="force_update_title">Vyžaduje sa aktualizácia</string>
+    <string name="force_update_message">Táto verzia aplikácie už nie je podporovaná. Pre pokračovanie ju prosím aktualizujte.</string>
 
     <!-- Settings screen -->
     <string name="settings_title">Nastavenia</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -143,6 +143,8 @@
     <!-- Update notification -->
     <string name="update_available">Доступна нова версія %1$s</string>
     <string name="update_download">Завантажити</string>
+    <string name="force_update_title">Потрібне оновлення</string>
+    <string name="force_update_message">Ця версія застосунку більше не підтримується. Щоб продовжити, оновіть її.</string>
 
     <!-- Settings screen -->
     <string name="settings_title">Налаштування</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,6 +143,8 @@
     <!-- Update notification -->
     <string name="update_available">New version %1$s available</string>
     <string name="update_download">Download</string>
+    <string name="force_update_title">Update required</string>
+    <string name="force_update_message">This version of the app is no longer supported. Please update to continue.</string>
 
     <!-- Settings screen -->
     <string name="settings_title">Settings</string>


### PR DESCRIPTION
Android side of the server-enforced force-update gate. Paired with the web PR cyklokoalicia/OpenSourceBikeShare#344.

The **web** is the source of truth for the minimum supported version (`ANDROID_MIN_SUPPORTED_VERSION`, default 1.1.0) and rejects too-old clients at the `/api/v1` firewall with **`426 Upgrade Required`**. This PR makes the app react to that.

## Changes
- `UpgradeRequiredInterceptor` — OkHttp interceptor that maps a `426` to `SessionEvent.UpdateRequired` (mirrors `PhoneUnconfirmedInterceptor` for `403 phone_unconfirmed`). Wired in `NetworkModule`.
- `AppViewModel.forceUpdateUrl` — set on `UpdateRequired`; fetches the **latest GitHub release** URL via the existing `UpdateChecker` (the `426` carries no URL; falls back to `WEBSITE_URL`).
- `AppNavGraph` — when `forceUpdateUrl != null`, the new full-screen, back-disabled `ForceUpdateScreen` supersedes the whole nav graph.
- Soft "update available" snackbar unchanged (GitHub-sourced, orthogonal).

## Notes
- No client-side version comparison / GitHub `min-supported:` marker — the gate is server-enforced (the earlier client-side draft was dropped).
- Strings added in en/sk/uk.

## Tests
`./gradlew test` + `lint` green. The interceptor is pure status-code wiring (no MockWebServer in the project); the gate decision is covered by the web suite.