### PR TITLE
Surface rent/return error reason instead of raw HTTP 409 (spec 0011)

### DIFF
--- a/app/src/main/java/com/bikeshare/app/data/api/dto/Envelope.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/dto/Envelope.kt
@@ -16,15 +16,20 @@ data class ResponseMeta(
     @Json(name = "timestamp") val timestamp: String? = null,
 )
 
-/** application/problem+json error body */
+/**
+ * application/problem+json error body. All fields are optional: a problem+json may omit
+ * any RFC-7807 member, and we must still surface whatever it carries. With the previous
+ * non-null fields, Moshi threw on any missing member, so a partial body made the caller
+ * discard `detail`/`code` and fall back to a raw "HTTP <status>" line (spec 0011).
+ */
 @JsonClass(generateAdapter = true)
 data class ProblemDetail(
-    @Json(name = "type") val type: String,
-    @Json(name = "title") val title: String,
-    @Json(name = "status") val status: Int,
-    @Json(name = "detail") val detail: String,
-    @Json(name = "instance") val instance: String,
-    @Json(name = "requestId") val requestId: String,
+    @Json(name = "type") val type: String? = null,
+    @Json(name = "title") val title: String? = null,
+    @Json(name = "status") val status: Int? = null,
+    @Json(name = "detail") val detail: String? = null,
+    @Json(name = "instance") val instance: String? = null,
+    @Json(name = "requestId") val requestId: String? = null,
     @Json(name = "code") val code: String? = null,
     @Json(name = "params") val params: Map<String, Any?>? = null,
 )

--- a/app/src/test/java/com/bikeshare/app/util/SafeApiCallErrorTest.kt
+++ b/app/src/test/java/com/bikeshare/app/util/SafeApiCallErrorTest.kt
@@ -1,0 +1,79 @@
+package com.bikeshare.app.util
+
+import com.bikeshare.app.data.api.dto.ApiEnvelope
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+
+/**
+ * Regression for spec 0011: the app showed a raw "HTTP 409" on rent rejection instead of
+ * the problem+json reason. The error mapper must surface `detail` + `code` whenever the
+ * body carries them, even if the body omits some RFC-7807 fields, and fall back to the
+ * generic HTTP line only when the body is genuinely absent/unparseable.
+ */
+class SafeApiCallErrorTest {
+
+    private val moshi = Moshi.Builder().build()
+
+    private fun mapError(code: Int, body: String): NetworkResult.Error {
+        val responseBody = body.toResponseBody("application/problem+json".toMediaType())
+        val result = runBlocking {
+            safeApiCall<Any>(moshi) { Response.error(code, responseBody) }
+        }
+        return result as NetworkResult.Error
+    }
+
+    @Test
+    fun `full problem+json surfaces detail and code`() {
+        val body = """
+            {"type":"about:blank","title":"Conflict","status":409,
+             "detail":"This bike is on a service stand and can't be rented.",
+             "instance":"/api/v1/bikes/rent","requestId":"abc",
+             "code":"bike.rent.error.service_stand","params":{}}
+        """.trimIndent()
+
+        val error = mapError(409, body)
+
+        assertEquals("This bike is on a service stand and can't be rented.", error.message)
+        assertEquals("bike.rent.error.service_stand", error.messageCode)
+        assertEquals(409, error.code)
+    }
+
+    @Test
+    fun `partial problem+json still surfaces detail and code`() {
+        // A body that omits some RFC-7807 fields (type/title/instance/requestId) must not
+        // make the mapper discard the reason and fall back to "HTTP 409".
+        val body = """
+            {"status":409,
+             "detail":"This bike is on a service stand and can't be rented.",
+             "code":"bike.rent.error.service_stand"}
+        """.trimIndent()
+
+        val error = mapError(409, body)
+
+        assertEquals("This bike is on a service stand and can't be rented.", error.message)
+        assertEquals("bike.rent.error.service_stand", error.messageCode)
+    }
+
+    @Test
+    fun `empty body falls back to the generic http line`() {
+        val error = mapError(409, "")
+
+        assertTrue(error.message.startsWith("HTTP 409"))
+        assertNull(error.messageCode)
+    }
+
+    @Test
+    fun `non-json body falls back to the generic http line`() {
+        val error = mapError(500, "Internal Server Error")
+
+        assertTrue(error.message.startsWith("HTTP 500"))
+        assertNull(error.messageCode)
+    }
+}


### PR DESCRIPTION
Fixes the bug where renting a bike on a service/inactive stand showed a bare **"HTTP 409"** instead of the reason.

## Root cause (refined while fixing)
The rent flow **already** parses problem+json and branches on `code`: `safeApiCall` reads `detail`/`code`/`params` into `NetworkResult.Error`, and `RentMessageRenderer` localizes per `code` (incl. `bike.rent.error.service_stand`) with `detail` as fallback.

The fault was the **`ProblemDetail` DTO**: its RFC-7807 fields (`type`/`title`/`status`/`detail`/`instance`/`requestId`) were **non-null**, so Moshi **threw** on any problem+json missing one. `safeApiCall`'s catch then discarded the whole body → `detail`/`code` lost → raw `HTTP <status>` fallback. A complete body already rendered fine; a partial one regressed to "HTTP 409".

## Fix
Make `ProblemDetail` **lenient** — all fields nullable with defaults — so a partial body still yields `detail`/`code`. No change to `safeApiCall` (already null-safe) or the renderer.

## Tests
`SafeApiCallErrorTest`: full body → `detail`+`code`; **partial body** → `detail`+`code` (the regression — failed before, passes after); empty / non-JSON → generic `HTTP <status>`. `./gradlew test` (4/4) + `lint` green.

Spec: `docs/specs/0011-*` (docs repo). Android-only; backend already correct.