### PR TITLE
Admin: tap a bike in a stand to open its detail (spec 0006)

### DIFF
--- a/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
@@ -41,6 +41,7 @@ fun MapScreen(
     onScanQr: () -> Unit,
     pendingQrUrl: String? = null,
     onQrConsumed: () -> Unit = {},
+    onBikeClick: ((Int) -> Unit)? = null,
     viewModel: MapViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -219,6 +220,12 @@ fun MapScreen(
                     onReturnBike = { bikeNumber ->
                         viewModel.returnBike(bikeNumber, selectedStand.standName)
                         showBottomSheet = false
+                    },
+                    onBikeClick = onBikeClick?.let { click ->
+                        { bikeNumber ->
+                            showBottomSheet = false
+                            click(bikeNumber)
+                        }
                     },
                 )
             }

--- a/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
@@ -223,7 +223,11 @@ fun MapScreen(
                     },
                     onBikeClick = onBikeClick?.let { click ->
                         { bikeNumber ->
+                            // Navigating away from the map: dismiss like onDismissRequest
+                            // (clear the stale stand selection/bike list), then open detail.
+                            // Unlike rent/return, we don't stay to refresh, so clearing is safe.
                             showBottomSheet = false
+                            viewModel.clearSelectedStand()
                             click(bikeNumber)
                         }
                     },

--- a/app/src/main/java/com/bikeshare/app/ui/map/StandBottomSheet.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/StandBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.bikeshare.app.ui.map
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -27,6 +28,7 @@ fun StandBottomSheet(
     myBikes: List<RentedBikeDto>,
     onRentBike: (Int) -> Unit,
     onReturnBike: (Int) -> Unit,
+    onBikeClick: ((Int) -> Unit)? = null,
 ) {
     Column(
         modifier = Modifier
@@ -92,7 +94,11 @@ fun StandBottomSheet(
                 modifier = Modifier.heightIn(max = 300.dp),
             ) {
                 items(bikes) { bike ->
-                    BikeItem(bike = bike, onRent = { onRentBike(bike.bikeNum) })
+                    BikeItem(
+                        bike = bike,
+                        onRent = { onRentBike(bike.bikeNum) },
+                        onClick = onBikeClick?.let { click -> { click(bike.bikeNum) } },
+                    )
                 }
             }
         }
@@ -108,6 +114,7 @@ private val ProblematicBikeContent = Color(0xFF664D03)
 private fun BikeItem(
     bike: BikeOnStandDto,
     onRent: () -> Unit,
+    onClick: (() -> Unit)? = null,
 ) {
     val hasNotes = !bike.notes.isNullOrBlank()
     val cardColors = if (hasNotes) {
@@ -118,8 +125,13 @@ private fun BikeItem(
     } else {
         CardDefaults.cardColors()
     }
+    // The whole row navigates to the bike detail when a handler is supplied (admins only,
+    // spec 0006); the Rent button keeps its own click. Non-admins get a null handler and
+    // a non-clickable card — the normal-user experience is unchanged.
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
         colors = cardColors,
     ) {
         Row(

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -259,6 +259,9 @@ fun AppNavGraph(
                     onScanQr = { navController.navigate(Screen.QrScanner.route) },
                     pendingQrUrl = pendingQrUrl,
                     onQrConsumed = onQrConsumed,
+                    // Admins can tap a bike in a stand to open its detail (spec 0006);
+                    // non-admins get a null handler and the row stays non-actionable.
+                    onBikeClick = adminBikeClick(isAdmin) { route -> navController.navigate(route) },
                 )
             }
 

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/Screen.kt
@@ -28,3 +28,16 @@ sealed class Screen(val route: String) {
     data object AdminCoupons : Screen("admin/coupons")
     data object AdminReports : Screen("admin/reports")
 }
+
+/**
+ * Click handler for a bike row in a stand's bike list (spec 0006): for an admin it opens
+ * that bike's detail; for a non-admin it is `null`, so the row stays non-actionable. The
+ * UI treats a null handler as "not tappable" (no ripple), keeping the normal-user
+ * experience unchanged.
+ */
+fun adminBikeClick(isAdmin: Boolean, onNavigate: (String) -> Unit): ((Int) -> Unit)? =
+    if (isAdmin) {
+        { bikeNumber -> onNavigate(Screen.AdminBikeDetail.createRoute(bikeNumber)) }
+    } else {
+        null
+    }

--- a/app/src/test/java/com/bikeshare/app/ui/navigation/AdminBikeClickTest.kt
+++ b/app/src/test/java/com/bikeshare/app/ui/navigation/AdminBikeClickTest.kt
@@ -1,0 +1,34 @@
+package com.bikeshare.app.ui.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Spec 0006: tapping a bike in a stand's list opens its detail — for admins only.
+ * The handler is the single source of that rule; the UI shows a tappable (rippling)
+ * row exactly when a handler is present.
+ */
+class AdminBikeClickTest {
+
+    @Test
+    fun `admin gets a handler that navigates to that bike's detail`() {
+        val navigated = mutableListOf<String>()
+        val handler = adminBikeClick(isAdmin = true) { navigated += it }
+
+        assertNotNull(handler)
+        handler!!(42)
+        assertEquals(listOf("admin/bikes/42"), navigated)
+    }
+
+    @Test
+    fun `non-admin gets no handler so the row is not actionable`() {
+        val navigated = mutableListOf<String>()
+        val handler = adminBikeClick(isAdmin = false) { navigated += it }
+
+        assertNull(handler)
+        assertTrue(navigated.isEmpty())
+    }
+}


### PR DESCRIPTION
For an authenticated **admin**, tapping a bike row in a stand's bike list now opens that bike's detail screen — instead of leaving the stand and searching the number under Admin → Bikes.

## Changes (Android-only)
- `adminBikeClick(isAdmin, onNavigate): ((Int) -> Unit)?` (`Screen.kt`) — the single gating seam: returns a handler for admins, `null` otherwise.
- `AppNavGraph` builds it from the already-known `isAdmin` and passes `onBikeClick` into `MapScreen` → `StandBottomSheet` → `BikeItem`.
- The bike-row `Card` is `clickable` **only when the handler is present** (admins) → the ripple affordance is admin-only; non-admin rows are unchanged. Tapping closes the sheet and navigates to the existing `AdminBikeDetail`; the per-row Rent button keeps its own click.
- No API/DTO change.

## Admin-only
The transition is strictly admin-gated: non-admins get a `null` handler (row not actionable), verified by `AdminBikeClickTest`.

## Tests
`AdminBikeClickTest` (pure unit): admin → navigates to `admin/bikes/{n}`; non-admin → `null`. `./gradlew test` + `lint` green. (Repo has no CI-runnable Compose/instrumented harness, so the one-line `clickable` wiring is covered by build/lint + manual.)

Spec: `docs/specs/0006-*`.