### PR TITLE
Map: draw service stands below active ones (spec 0010, android)

### DIFF
--- a/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
@@ -166,8 +166,8 @@ fun MapScreen(
                     // Draw service/testing stands first so active stands stay on top (spec 0010).
                     standsInDrawOrder(uiState.stands).forEach { stand ->
                         val (markerColor, label, statusLabel) = when (stand.status) {
-                            "technical" -> Triple(AndroidColor.parseColor("#FF9800"), "S", serviceStandLabel)
-                            "hidden" -> Triple(AndroidColor.parseColor("#9C27B0"), "H", hiddenStandLabel)
+                            STATUS_TECHNICAL -> Triple(AndroidColor.parseColor("#FF9800"), "S", serviceStandLabel)
+                            STATUS_HIDDEN -> Triple(AndroidColor.parseColor("#9C27B0"), "H", hiddenStandLabel)
                             else -> {
                                 val bikes = stand.bikeCount ?: 0
                                 val color = if (bikes > 0) AndroidColor.parseColor("#4CAF50") else AndroidColor.parseColor("#F44336")

--- a/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/MapScreen.kt
@@ -163,7 +163,8 @@ fun MapScreen(
                 update = { mapView ->
                     mapViewRef.value = mapView
                     mapView.overlays.removeAll { it is Marker }
-                    uiState.stands.forEach { stand ->
+                    // Draw service/testing stands first so active stands stay on top (spec 0010).
+                    standsInDrawOrder(uiState.stands).forEach { stand ->
                         val (markerColor, label, statusLabel) = when (stand.status) {
                             "technical" -> Triple(AndroidColor.parseColor("#FF9800"), "S", serviceStandLabel)
                             "hidden" -> Triple(AndroidColor.parseColor("#9C27B0"), "H", hiddenStandLabel)

--- a/app/src/main/java/com/bikeshare/app/ui/map/StandDrawOrder.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/StandDrawOrder.kt
@@ -2,9 +2,13 @@ package com.bikeshare.app.ui.map
 
 import com.bikeshare.app.data.api.dto.StandMarkerDto
 
-/** Stand statuses that render as non-rideable "background" markers (service / testing). */
-private const val STATUS_TECHNICAL = "technical"
-private const val STATUS_HIDDEN = "hidden"
+/**
+ * Stand statuses that render as non-rideable "background" markers (service / testing).
+ * Shared within the map UI (also used by MapScreen's marker styling) so the status
+ * vocabulary lives in one place here.
+ */
+internal const val STATUS_TECHNICAL = "technical"
+internal const val STATUS_HIDDEN = "hidden"
 
 /**
  * Map layer for a stand by status (spec 0010): service ("technical") and testing
@@ -17,7 +21,10 @@ internal fun standDrawLayer(status: String?): Int =
 /**
  * Orders stands for map drawing: lower layers first. osmdroid draws later-added overlays
  * on top, so service/testing markers (layer 0) are added before — and sit below —
- * active markers (layer 1). Stable: fetch order is preserved within each layer.
+ * active markers (layer 1). A stable partition (not a sort) preserves fetch order within
+ * each layer in O(n), since there are only two layers.
  */
-fun standsInDrawOrder(stands: List<StandMarkerDto>): List<StandMarkerDto> =
-    stands.sortedBy { standDrawLayer(it.status) }
+fun standsInDrawOrder(stands: List<StandMarkerDto>): List<StandMarkerDto> {
+    val (background, foreground) = stands.partition { standDrawLayer(it.status) == 0 }
+    return background + foreground
+}

--- a/app/src/main/java/com/bikeshare/app/ui/map/StandDrawOrder.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/StandDrawOrder.kt
@@ -1,0 +1,23 @@
+package com.bikeshare.app.ui.map
+
+import com.bikeshare.app.data.api.dto.StandMarkerDto
+
+/** Stand statuses that render as non-rideable "background" markers (service / testing). */
+private const val STATUS_TECHNICAL = "technical"
+private const val STATUS_HIDDEN = "hidden"
+
+/**
+ * Map layer for a stand by status (spec 0010): service ("technical") and testing
+ * ("hidden") stands sit on a lower layer (0); active/parking stands on top (1), so an
+ * active stand is never hidden behind a service marker. The single status→layer mapping.
+ */
+internal fun standDrawLayer(status: String?): Int =
+    if (status == STATUS_TECHNICAL || status == STATUS_HIDDEN) 0 else 1
+
+/**
+ * Orders stands for map drawing: lower layers first. osmdroid draws later-added overlays
+ * on top, so service/testing markers (layer 0) are added before — and sit below —
+ * active markers (layer 1). Stable: fetch order is preserved within each layer.
+ */
+fun standsInDrawOrder(stands: List<StandMarkerDto>): List<StandMarkerDto> =
+    stands.sortedBy { standDrawLayer(it.status) }

--- a/app/src/test/java/com/bikeshare/app/ui/map/StandDrawOrderTest.kt
+++ b/app/src/test/java/com/bikeshare/app/ui/map/StandDrawOrderTest.kt
@@ -1,0 +1,53 @@
+package com.bikeshare.app.ui.map
+
+import com.bikeshare.app.data.api.dto.StandMarkerDto
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Spec 0010: service ("technical") and testing ("hidden") stands must be drawn before
+ * (below) active stands so an active stand is never hidden behind a service marker.
+ */
+class StandDrawOrderTest {
+
+    private fun stand(name: String, status: String?) =
+        StandMarkerDto(standName = name, latitude = 0.0, longitude = 0.0, status = status)
+
+    @Test
+    fun `service and testing stands are ordered before active ones`() {
+        val stands = listOf(
+            stand("active1", "active"),
+            stand("service", "technical"),
+            stand("active2", null),
+            stand("testing", "hidden"),
+        )
+
+        val ordered = standsInDrawOrder(stands).map { it.standName }
+
+        // layer 0 (service/testing) first, layer 1 (active) last
+        assertEquals(listOf("service", "testing", "active1", "active2"), ordered)
+    }
+
+    @Test
+    fun `fetch order is preserved within each layer (stable)`() {
+        val stands = listOf(
+            stand("a", "active"),
+            stand("b", "active"),
+            stand("s1", "technical"),
+            stand("s2", "technical"),
+        )
+
+        val ordered = standsInDrawOrder(stands).map { it.standName }
+
+        assertEquals(listOf("s1", "s2", "a", "b"), ordered)
+    }
+
+    @Test
+    fun `layer mapping puts only technical and hidden below`() {
+        assertEquals(0, standDrawLayer("technical"))
+        assertEquals(0, standDrawLayer("hidden"))
+        assertEquals(1, standDrawLayer("active"))
+        assertEquals(1, standDrawLayer(null))
+        assertEquals(1, standDrawLayer("inactive"))
+    }
+}


### PR DESCRIPTION
Android half of spec 0010 (paired with web cyklokoalicia/OpenSourceBikeShare#345). Active/parking stands are no longer hidden behind overlapping service markers on the osmdroid map.

## Change
- `standsInDrawOrder(stands)` (`ui/map/StandDrawOrder.kt`) stable-sorts by `standDrawLayer(status)`: `technical`/`hidden` → layer 0, everything else → layer 1.
- `MapScreen` iterates that ordered list when adding `Marker` overlays. osmdroid draws later-added overlays on top, so service/testing markers (added first) sit **below** active markers (added last). Stable sort preserves fetch order within a layer.
- Single status→layer mapping in `standDrawLayer`. No new DTO/ViewModel state.

## Status→layer
Below = `technical` (service) + `hidden` (testing); on top = everything else. Same mapping as web.

## Tests
`StandDrawOrderTest`: ordering (service before active), stability within a layer, and the `standDrawLayer` mapping. `./gradlew test` + `lint` green.

Spec: `docs/specs/0010-*`.