### PR TITLE
Show the stand photo in the stand detail (spec 0007)

### DIFF
--- a/app/src/main/java/com/bikeshare/app/ui/map/StandBottomSheet.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/map/StandBottomSheet.kt
@@ -2,6 +2,7 @@ package com.bikeshare.app.ui.map
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -12,10 +13,13 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.bikeshare.app.R
 import com.bikeshare.app.data.api.dto.BikeOnStandDto
 import com.bikeshare.app.data.api.dto.RentedBikeDto
@@ -40,6 +44,21 @@ fun StandBottomSheet(
             style = MaterialTheme.typography.headlineMedium,
             fontWeight = FontWeight.Bold,
         )
+
+        // Stand photo between the title and the description (spec 0007). standPhoto is a
+        // full URL; hidden when empty/null.
+        stand.standPhoto?.takeIf { it.isNotBlank() }?.let { photoUrl ->
+            Spacer(modifier = Modifier.height(8.dp))
+            AsyncImage(
+                model = photoUrl,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 180.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+                contentScale = ContentScale.Crop,
+            )
+        }
 
         stand.standDescription?.let {
             Text(

--- a/app/src/test/java/com/bikeshare/app/data/api/dto/StandMarkerDtoParsingTest.kt
+++ b/app/src/test/java/com/bikeshare/app/data/api/dto/StandMarkerDtoParsingTest.kt
@@ -1,0 +1,38 @@
+package com.bikeshare.app.data.api.dto
+
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Spec 0007: the stand photo is shown in the stand detail. The API already returns
+ * `standPhoto` as a full URL on the markers/stand response, so the app reuses it — these
+ * guard that the field deserializes (URL when set, null when absent).
+ */
+class StandMarkerDtoParsingTest {
+
+    private val adapter = Moshi.Builder().build().adapter(StandMarkerDto::class.java)
+
+    @Test
+    fun `standPhoto is parsed when present`() {
+        val json = """
+            {"standId":7,"standName":"STAND7","latitude":48.1,"longitude":17.1,
+             "bikeCount":3,"status":"active",
+             "standPhoto":"https://example.com/stands/stand7.jpg"}
+        """.trimIndent()
+
+        val dto = adapter.fromJson(json)
+
+        assertEquals("https://example.com/stands/stand7.jpg", dto?.standPhoto)
+    }
+
+    @Test
+    fun `standPhoto is null when absent`() {
+        val json = """{"standName":"STAND7","latitude":48.1,"longitude":17.1}"""
+
+        val dto = adapter.fromJson(json)
+
+        assertNull(dto?.standPhoto)
+    }
+}


### PR DESCRIPTION
Shows the stand's photo in the stand detail (bottom sheet), between the title and the description.

## Scope: Android-only
Investigation showed the seam already exists end-to-end: `StandRepository` selects `standPhoto`, the `/api/v1/stands/markers` response carries it, and `StandMarkerDto` already deserializes it. Per the deployment, `standPhoto` is stored as a **full URL** (the web renders it directly as `<img src>`; SMS sends it as a photo link). So **no API change** and no new `photoUrl` field — the app reuses the existing `standPhoto`.

## Change
- `StandBottomSheet`: Coil `AsyncImage(model = standPhoto)` between title and description — full-width, `heightIn(max = 180.dp)`, rounded corners, `ContentScale.Crop`; shown only when `standPhoto` is non-blank.

## Tests
`StandMarkerDtoParsingTest` (standPhoto parses to the URL when set, null when absent). `./gradlew test` + `lint` green. (Render is a one-block Compose conditional; no CI-runnable Compose harness → build/lint + manual.)

Spec: `docs/specs/0007-*` (updated: API change dropped given the full-URL format).