### PR TITLE
fix: send version User-Agent on token refresh (stop 426 logout loop)

### DIFF
--- a/app/src/main/java/com/bikeshare/app/data/api/ApiUserAgent.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/ApiUserAgent.kt
@@ -1,0 +1,21 @@
+package com.bikeshare.app.data.api
+
+import com.bikeshare.app.BuildConfig
+
+/**
+ * The single source of truth for the HTTP `User-Agent` on all app→API traffic. It MUST be
+ * sent on every request — including the bare token-refresh client — because the server's
+ * force-update gate (spec 0005) reads the app version out of it via the
+ * `…-Android/<versionName> (<versionCode>)` shape. A missing or non-versioned UA is read as
+ * "0.0.0" and rejected with 426, which previously wiped the session on every token refresh
+ * (spec 0015). Keep this the only place the UA string is built.
+ */
+object ApiUserAgent {
+
+    /** Builds the UA from explicit version parts (kept separate so it is unit-testable). */
+    fun format(versionName: String, versionCode: Int): String =
+        "${BuildConfig.APP_NAME}-Android/$versionName ($versionCode)"
+
+    /** The UA for this build. */
+    val value: String = format(BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE)
+}

--- a/app/src/main/java/com/bikeshare/app/data/api/TokenRefreshAuthenticator.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/TokenRefreshAuthenticator.kt
@@ -1,12 +1,16 @@
 package com.bikeshare.app.data.api
 
+import com.bikeshare.app.BuildConfig
 import com.bikeshare.app.data.api.dto.ApiEnvelope
 import com.bikeshare.app.data.api.dto.AuthTokens
 import com.bikeshare.app.data.api.dto.RefreshRequest
 import com.bikeshare.app.data.local.TokenStorage
+import com.bikeshare.app.util.SessionEvent
+import com.bikeshare.app.util.SessionEventBus
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import okhttp3.Authenticator
+import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -19,6 +23,7 @@ import javax.inject.Inject
 class TokenRefreshAuthenticator @Inject constructor(
     private val tokenStorage: TokenStorage,
     private val moshi: Moshi,
+    private val sessionEventBus: SessionEventBus,
 ) : Authenticator {
 
     private val refreshClient: OkHttpClient by lazy { OkHttpClient.Builder().build() }
@@ -28,55 +33,106 @@ class TokenRefreshAuthenticator @Inject constructor(
         // Only retry once
         if (response.request.header("X-Retry") != null) return null
 
-        val refreshToken = tokenStorage.getRefreshToken() ?: return null
+        val refreshToken = tokenStorage.getRefreshToken()
+        if (refreshToken == null) {
+            // No refresh token at all → the session is genuinely gone.
+            endSession()
+            return null
+        }
 
-        val newTokens = refreshAccessToken(refreshToken, response.request)
-        return if (newTokens != null) {
-            tokenStorage.saveTokens(
-                newTokens.accessToken,
-                newTokens.refreshToken,
-            )
-            response.request.newBuilder()
-                .header("Authorization", "Bearer ${newTokens.accessToken}")
-                .header("X-Retry", "true")
-                .build()
-        } else {
-            tokenStorage.clearTokens()
-            null
+        val refresh = runRefresh(refreshToken, response.request.url)
+
+        return when (decideOutcome(refresh.code, refresh.tokens)) {
+            Outcome.RETRY -> {
+                val tokens = refresh.tokens!!
+                tokenStorage.saveTokens(tokens.accessToken, tokens.refreshToken)
+                response.request.newBuilder()
+                    .header("Authorization", "Bearer ${tokens.accessToken}")
+                    .header("X-Retry", "true")
+                    .build()
+            }
+            // 401/403: the refresh token itself was rejected → the session is over.
+            Outcome.LOGOUT -> {
+                endSession()
+                null
+            }
+            // 426: this build is below the server's version floor (spec 0005). Surface the
+            // force-update screen instead of silently wiping a valid session.
+            Outcome.UPGRADE -> {
+                sessionEventBus.emit(SessionEvent.UpdateRequired)
+                null
+            }
+            // Transient failure (network, 5xx, unparseable 2xx): keep the refresh token so a
+            // later request can recover. This one request just fails for now.
+            Outcome.KEEP -> null
         }
     }
 
-    private fun refreshAccessToken(refreshToken: String, originalRequest: Request): AuthTokens? {
+    /** Clear the stored tokens and tell the UI to route to login (spec 0015). */
+    private fun endSession() {
+        tokenStorage.clearTokens()
+        sessionEventBus.emit(SessionEvent.SessionExpired)
+    }
+
+    private fun runRefresh(refreshToken: String, originalUrl: HttpUrl): RefreshResponse {
         return try {
-            val refreshBody = moshi.adapter(RefreshRequest::class.java)
-                .toJson(RefreshRequest(refreshToken))
-
-            val request = Request.Builder()
-                .url(
-                    originalRequest.url.newBuilder()
-                        .encodedPath("/api/v1/auth/refresh")
-                        .build()
-                )
-                .post(refreshBody.toRequestBody("application/json".toMediaType()))
-                .build()
-
-            val response = refreshClient.newCall(request).execute()
-
-            if (response.isSuccessful) {
-                val type = Types.newParameterizedType(
-                    ApiEnvelope::class.java,
-                    AuthTokens::class.java,
-                )
-                val adapter = moshi.adapter<ApiEnvelope<AuthTokens>>(type)
-                val body = response.body?.string()
-                body?.let { adapter.fromJson(it)?.data }
-            } else {
-                Timber.w("Token refresh failed with status ${response.code}")
-                null
+            refreshClient.newCall(buildRefreshRequest(originalUrl, refreshToken)).execute().use { response ->
+                val tokens = if (response.isSuccessful) {
+                    val type = Types.newParameterizedType(ApiEnvelope::class.java, AuthTokens::class.java)
+                    val adapter = moshi.adapter<ApiEnvelope<AuthTokens>>(type)
+                    response.body?.string()?.let { adapter.fromJson(it)?.data }
+                } else {
+                    Timber.w("Token refresh failed with status ${response.code}")
+                    null
+                }
+                RefreshResponse(response.code, tokens)
             }
         } catch (e: Exception) {
             Timber.e(e, "Token refresh error")
-            null
+            RefreshResponse(code = null, tokens = null)
+        }
+    }
+
+    private fun buildRefreshRequest(originalUrl: HttpUrl, refreshToken: String): Request {
+        val refreshBody = moshi.adapter(RefreshRequest::class.java)
+            .toJson(RefreshRequest(refreshToken))
+        return Request.Builder()
+            .url(originalUrl.newBuilder().encodedPath(REFRESH_PATH).build())
+            // The refresh runs on a bare client (no shared interceptors), so it must carry
+            // the same version User-Agent the main client sends — otherwise the server's
+            // force-update gate (spec 0005) reads it as "0.0.0" and returns 426, which would
+            // wipe the session on every token expiry (spec 0015).
+            .header("User-Agent", USER_AGENT)
+            .post(refreshBody.toRequestBody("application/json".toMediaType()))
+            .build()
+    }
+
+    private data class RefreshResponse(val code: Int?, val tokens: AuthTokens?)
+
+    enum class Outcome { RETRY, LOGOUT, UPGRADE, KEEP }
+
+    companion object {
+        private const val REFRESH_PATH = "/api/v1/auth/refresh"
+
+        /** Same format the main client sends (`NetworkModule`), so the version gate sees the real version. */
+        fun userAgent(versionName: String, versionCode: Int): String =
+            "${BuildConfig.APP_NAME}-Android/$versionName ($versionCode)"
+
+        val USER_AGENT: String = userAgent(BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE)
+
+        /**
+         * Map a refresh attempt to what we do with the session:
+         * - success carrying tokens → [Outcome.RETRY]
+         * - 401/403 (refresh token rejected) → [Outcome.LOGOUT] (clear + route to login)
+         * - 426 (below the version floor, spec 0005) → [Outcome.UPGRADE] (force-update, keep tokens)
+         * - anything else: 5xx, network error (`code == null`), or a 2xx without a parseable
+         *   body → [Outcome.KEEP] (do not discard a still-valid refresh token)
+         */
+        fun decideOutcome(code: Int?, tokens: AuthTokens?): Outcome = when {
+            tokens != null -> Outcome.RETRY
+            code == 401 || code == 403 -> Outcome.LOGOUT
+            code == 426 -> Outcome.UPGRADE
+            else -> Outcome.KEEP
         }
     }
 }

--- a/app/src/main/java/com/bikeshare/app/data/api/TokenRefreshAuthenticator.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/TokenRefreshAuthenticator.kt
@@ -110,6 +110,9 @@ class TokenRefreshAuthenticator @Inject constructor(
 
     companion object {
         private const val REFRESH_PATH = "/api/v1/auth/refresh"
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_FORBIDDEN = 403
+        private const val HTTP_UPGRADE_REQUIRED = 426
 
         /**
          * Map a refresh attempt to what we do with the session:
@@ -121,8 +124,8 @@ class TokenRefreshAuthenticator @Inject constructor(
          */
         fun decideOutcome(code: Int?, tokens: AuthTokens?): Outcome = when {
             tokens != null -> Outcome.RETRY
-            code == 401 || code == 403 -> Outcome.LOGOUT
-            code == 426 -> Outcome.UPGRADE
+            code == HTTP_UNAUTHORIZED || code == HTTP_FORBIDDEN -> Outcome.LOGOUT
+            code == HTTP_UPGRADE_REQUIRED -> Outcome.UPGRADE
             else -> Outcome.KEEP
         }
     }

--- a/app/src/main/java/com/bikeshare/app/data/api/TokenRefreshAuthenticator.kt
+++ b/app/src/main/java/com/bikeshare/app/data/api/TokenRefreshAuthenticator.kt
@@ -1,6 +1,5 @@
 package com.bikeshare.app.data.api
 
-import com.bikeshare.app.BuildConfig
 import com.bikeshare.app.data.api.dto.ApiEnvelope
 import com.bikeshare.app.data.api.dto.AuthTokens
 import com.bikeshare.app.data.api.dto.RefreshRequest
@@ -33,12 +32,10 @@ class TokenRefreshAuthenticator @Inject constructor(
         // Only retry once
         if (response.request.header("X-Retry") != null) return null
 
-        val refreshToken = tokenStorage.getRefreshToken()
-        if (refreshToken == null) {
-            // No refresh token at all → the session is genuinely gone.
-            endSession()
-            return null
-        }
+        // No refresh token → there is no session to refresh or expire (tokens are saved and
+        // cleared as a pair, so this means "not logged in"). Let the 401 surface as-is; the
+        // login flow handles it. Only a *rejected* refresh token (below) ends a live session.
+        val refreshToken = tokenStorage.getRefreshToken() ?: return null
 
         val refresh = runRefresh(refreshToken, response.request.url)
 
@@ -98,11 +95,11 @@ class TokenRefreshAuthenticator @Inject constructor(
             .toJson(RefreshRequest(refreshToken))
         return Request.Builder()
             .url(originalUrl.newBuilder().encodedPath(REFRESH_PATH).build())
-            // The refresh runs on a bare client (no shared interceptors), so it must carry
-            // the same version User-Agent the main client sends — otherwise the server's
-            // force-update gate (spec 0005) reads it as "0.0.0" and returns 426, which would
-            // wipe the session on every token expiry (spec 0015).
-            .header("User-Agent", USER_AGENT)
+            // The refresh runs on a bare client (no shared interceptors), so it must carry the
+            // same version User-Agent the main client sends ([ApiUserAgent], the single source
+            // of truth) — otherwise the server's force-update gate (spec 0005) reads it as
+            // "0.0.0" and returns 426, which would wipe the session on every refresh (spec 0015).
+            .header("User-Agent", ApiUserAgent.value)
             .post(refreshBody.toRequestBody("application/json".toMediaType()))
             .build()
     }
@@ -113,12 +110,6 @@ class TokenRefreshAuthenticator @Inject constructor(
 
     companion object {
         private const val REFRESH_PATH = "/api/v1/auth/refresh"
-
-        /** Same format the main client sends (`NetworkModule`), so the version gate sees the real version. */
-        fun userAgent(versionName: String, versionCode: Int): String =
-            "${BuildConfig.APP_NAME}-Android/$versionName ($versionCode)"
-
-        val USER_AGENT: String = userAgent(BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE)
 
         /**
          * Map a refresh attempt to what we do with the session:

--- a/app/src/main/java/com/bikeshare/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/bikeshare/app/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.bikeshare.app.di
 
 import com.bikeshare.app.BuildConfig
 import com.bikeshare.app.data.api.ApiService
+import com.bikeshare.app.data.api.ApiUserAgent
 import com.bikeshare.app.data.api.AuthInterceptor
 import com.bikeshare.app.data.api.PhoneUnconfirmedInterceptor
 import com.bikeshare.app.data.api.TokenRefreshAuthenticator
@@ -38,7 +39,7 @@ object NetworkModule {
         val builder = OkHttpClient.Builder()
             .addInterceptor { chain ->
                 val request = chain.request().newBuilder()
-                    .header("User-Agent", "${BuildConfig.APP_NAME}-Android/${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+                    .header("User-Agent", ApiUserAgent.value)
                     .build()
                 chain.proceed(request)
             }

--- a/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/bikeshare/app/ui/navigation/AppNavGraph.kt
@@ -115,6 +115,16 @@ fun AppNavGraph(
                 // UpdateRequired is handled by AppViewModel (sets forceUpdateUrl, which
                 // blocks above via ForceUpdateScreen); no navigation needed here.
                 SessionEvent.UpdateRequired -> Unit
+                // The session was wiped (refresh token rejected/absent, spec 0015) — route
+                // to login and clear the back stack instead of looping on token-less calls.
+                SessionEvent.SessionExpired -> {
+                    if (navController.currentDestination?.route != Screen.Login.route) {
+                        navController.navigate(Screen.Login.route) {
+                            popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/bikeshare/app/util/SessionEventBus.kt
+++ b/app/src/main/java/com/bikeshare/app/util/SessionEventBus.kt
@@ -1,5 +1,6 @@
 package com.bikeshare.app.util
 
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -32,7 +33,15 @@ sealed interface SessionEvent {
  */
 @Singleton
 class SessionEventBus @Inject constructor() {
-    private val _events = MutableSharedFlow<SessionEvent>(extraBufferCapacity = 1)
+    // DROP_OLDEST with a roomy buffer so tryEmit() never silently fails under back-pressure:
+    // critical events (notably SessionExpired, which the UI relies on to route to login once
+    // tokens are cleared) are buffered for the active collectors rather than dropped. replay
+    // stays 0 on purpose — a one-shot navigation event must not be re-delivered to a later
+    // collector (e.g. after re-login) and bounce the user back to login.
+    private val _events = MutableSharedFlow<SessionEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
     val events: SharedFlow<SessionEvent> = _events.asSharedFlow()
 
     fun emit(event: SessionEvent) {

--- a/app/src/main/java/com/bikeshare/app/util/SessionEventBus.kt
+++ b/app/src/main/java/com/bikeshare/app/util/SessionEventBus.kt
@@ -16,6 +16,13 @@ sealed interface SessionEvent {
      * below the configured minimum supported version (spec 0005). The UI must block.
      */
     data object UpdateRequired : SessionEvent
+
+    /**
+     * The session is genuinely gone — the refresh token was rejected (or absent), so the
+     * stored tokens were cleared (spec 0015). The UI must route to the login screen
+     * instead of looping on token-less "Authentication required" responses.
+     */
+    data object SessionExpired : SessionEvent
 }
 
 /**

--- a/app/src/test/java/com/bikeshare/app/data/api/TokenRefreshAuthenticatorTest.kt
+++ b/app/src/test/java/com/bikeshare/app/data/api/TokenRefreshAuthenticatorTest.kt
@@ -15,24 +15,22 @@ class TokenRefreshAuthenticatorTest {
     private val serverAndroidUaPattern = Regex("""^.+-Android/(\d+\.\d+\.\d+)\s*\(\d+\)$""")
 
     @Test
-    fun `a release-style refresh User-Agent is parseable by the server version gate`() {
+    fun `a release-style User-Agent is parseable by the server version gate`() {
         // A clean release version must match the server pattern, so the gate reads the real
         // version instead of falling back to "0.0.0" (→ 426). Uses a fixed release version so
         // the test does not depend on the build's versionName (which may carry a -debug suffix).
-        assertTrue(
-            serverAndroidUaPattern.matches(TokenRefreshAuthenticator.userAgent("1.1.6", 125)),
-        )
+        assertTrue(serverAndroidUaPattern.matches(ApiUserAgent.format("1.1.6", 125)))
     }
 
     @Test
-    fun `refresh sends the app User-Agent, not okhttp's default`() {
+    fun `the app User-Agent is not okhttp's default`() {
         // The bug (spec 0015): the bare refresh client sent the default `okhttp/…` UA, which
-        // the server reads as "0.0.0" and rejects with 426. The refresh UA must be the app's.
+        // the server reads as "0.0.0" and rejects with 426. The shared UA must be the app's.
         assertTrue(
-            "Refresh UA '${TokenRefreshAuthenticator.USER_AGENT}' must be the app UA, not okhttp's default",
-            TokenRefreshAuthenticator.USER_AGENT.contains("-Android/"),
+            "UA '${ApiUserAgent.value}' must be the app UA, not okhttp's default",
+            ApiUserAgent.value.contains("-Android/"),
         )
-        assertFalse(TokenRefreshAuthenticator.USER_AGENT.startsWith("okhttp/"))
+        assertFalse(ApiUserAgent.value.startsWith("okhttp/"))
     }
 
     @Test

--- a/app/src/test/java/com/bikeshare/app/data/api/TokenRefreshAuthenticatorTest.kt
+++ b/app/src/test/java/com/bikeshare/app/data/api/TokenRefreshAuthenticatorTest.kt
@@ -1,0 +1,64 @@
+package com.bikeshare.app.data.api
+
+import com.bikeshare.app.data.api.dto.AuthTokens
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TokenRefreshAuthenticatorTest {
+
+    // The exact regex the server uses to read the Android version off the User-Agent
+    // (BikeShare-web ClientVersionDetector.ANDROID_UA_PATTERN). A UA that does not match
+    // is treated as "0.0.0" and gated with 426 — which is the bug (spec 0015): the bare
+    // refresh client sent the default `okhttp/…` UA, so every refresh was rejected.
+    private val serverAndroidUaPattern = Regex("""^.+-Android/(\d+\.\d+\.\d+)\s*\(\d+\)$""")
+
+    @Test
+    fun `a release-style refresh User-Agent is parseable by the server version gate`() {
+        // A clean release version must match the server pattern, so the gate reads the real
+        // version instead of falling back to "0.0.0" (→ 426). Uses a fixed release version so
+        // the test does not depend on the build's versionName (which may carry a -debug suffix).
+        assertTrue(
+            serverAndroidUaPattern.matches(TokenRefreshAuthenticator.userAgent("1.1.6", 125)),
+        )
+    }
+
+    @Test
+    fun `refresh sends the app User-Agent, not okhttp's default`() {
+        // The bug (spec 0015): the bare refresh client sent the default `okhttp/…` UA, which
+        // the server reads as "0.0.0" and rejects with 426. The refresh UA must be the app's.
+        assertTrue(
+            "Refresh UA '${TokenRefreshAuthenticator.USER_AGENT}' must be the app UA, not okhttp's default",
+            TokenRefreshAuthenticator.USER_AGENT.contains("-Android/"),
+        )
+        assertFalse(TokenRefreshAuthenticator.USER_AGENT.startsWith("okhttp/"))
+    }
+
+    @Test
+    fun `successful refresh with tokens retries the request`() {
+        val tokens = AuthTokens(accessToken = "a", refreshToken = "r")
+        assertEquals(TokenRefreshAuthenticator.Outcome.RETRY, TokenRefreshAuthenticator.decideOutcome(200, tokens))
+    }
+
+    @Test
+    fun `rejected refresh token (401 or 403) ends the session`() {
+        assertEquals(TokenRefreshAuthenticator.Outcome.LOGOUT, TokenRefreshAuthenticator.decideOutcome(401, null))
+        assertEquals(TokenRefreshAuthenticator.Outcome.LOGOUT, TokenRefreshAuthenticator.decideOutcome(403, null))
+    }
+
+    @Test
+    fun `426 triggers force-update, not logout`() {
+        assertEquals(TokenRefreshAuthenticator.Outcome.UPGRADE, TokenRefreshAuthenticator.decideOutcome(426, null))
+    }
+
+    @Test
+    fun `transient failures keep the tokens`() {
+        // 5xx, a network error (null code), and a 2xx with no parseable body must NOT
+        // discard a still-valid 30-day refresh token.
+        assertEquals(TokenRefreshAuthenticator.Outcome.KEEP, TokenRefreshAuthenticator.decideOutcome(500, null))
+        assertEquals(TokenRefreshAuthenticator.Outcome.KEEP, TokenRefreshAuthenticator.decideOutcome(502, null))
+        assertEquals(TokenRefreshAuthenticator.Outcome.KEEP, TokenRefreshAuthenticator.decideOutcome(null, null))
+        assertEquals(TokenRefreshAuthenticator.Outcome.KEEP, TokenRefreshAuthenticator.decideOutcome(200, null))
+    }
+}


### PR DESCRIPTION
## Problem

Every logged-in user is silently logged out roughly every access-token expiry: the app loops on a `401 "Authentication required"` toast and the admin tab disappears. Re-logging in fixes it temporarily, then it recurs.

## Root cause

`TokenRefreshAuthenticator` refreshes through a **separate, bare** `OkHttpClient` with no interceptors, so `POST /api/v1/auth/refresh` is sent with OkHttp's default `okhttp/…` User-Agent — not the versioned UA the main client adds in `NetworkModule`. Server-side, `ClientVersionDetector` maps an `okhttp/…` UA to `0.0.0`, and the force-update gate (spec 0005) returns **426**. The authenticator treated any non-2xx refresh as failure → `clearTokens()` → every subsequent request is token-less → `401 "Authentication required"` loop; `getMyLimits()` failing hides the admin tab.

Verified live against `whitebikes.info`:

| `User-Agent` on `/auth/refresh` | Response |
| --- | --- |
| `okhttp/4.12.0` (old) | **426** `upgrade_required` |
| `BikeShare-Android/1.1.6 (125)` (fixed) | **401** `Invalid refresh token` (gate passed) |

## Fix

- Send the same versioned `User-Agent` the main client uses on the refresh request.
- Classify the refresh outcome by status: `401/403` → end session; `426` → force-update screen; `5xx`/network/unparseable-2xx → keep the tokens (don't discard a valid 30-day refresh token on a transient blip).
- On genuine session loss, emit a new `SessionEvent.SessionExpired` and route to the login screen instead of looping on token-less requests.

## Tests

`TokenRefreshAuthenticatorTest` (6 cases): refresh UA is parseable by the server gate and is not okhttp's default; `decideOutcome` maps each status correctly. `./gradlew test` + `lint` green.

Spec: `docs/specs/0015-fix-android-refresh-426-logout.md`